### PR TITLE
regen meter: resync spec orb from actual energy gains

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -32,7 +32,9 @@ import javax.inject.Inject;
 import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
+import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.GameState;
+import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.Prayer;
 import net.runelite.api.Skill;
@@ -47,6 +49,7 @@ import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.game.ItemVariationMapping;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
@@ -84,6 +87,7 @@ public class RegenMeterPlugin extends Plugin
 
 	private int ticksSinceSpecRegen;
 	private int ticksSinceHPRegen;
+	private int lastSpecEnergy = -1;
 
 	private boolean wearingLightbearer;
 
@@ -97,6 +101,7 @@ public class RegenMeterPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		overlayManager.add(overlay);
+		lastSpecEnergy = client.getVarpValue(VarPlayerID.SA_ENERGY);
 	}
 
 	@Override
@@ -112,6 +117,7 @@ public class RegenMeterPlugin extends Plugin
 		{
 			ticksSinceHPRegen = -2; // For some reason this makes this accurate
 			ticksSinceSpecRegen = 0;
+			lastSpecEnergy = -1;
 		}
 	}
 
@@ -124,7 +130,8 @@ public class RegenMeterPlugin extends Plugin
 		}
 
 		ItemContainer equipment = event.getItemContainer();
-		final boolean hasLightbearer = equipment.contains(ItemID.LIGHTBEARER);
+		final Item ring = equipment.getItem(EquipmentInventorySlot.RING.getSlotIdx());
+		final boolean hasLightbearer = ring != null && ItemVariationMapping.map(ring.getId()) == ItemID.LIGHTBEARER;
 		if (hasLightbearer == wearingLightbearer)
 		{
 			return;
@@ -149,16 +156,26 @@ public class RegenMeterPlugin extends Plugin
 	public void onGameTick(GameTick event)
 	{
 		final int ticksPerSpecRegen = wearingLightbearer ? SPEC_REGEN_TICKS / 2 : SPEC_REGEN_TICKS;
+		final int currentSpecEnergy = client.getVarpValue(VarPlayerID.SA_ENERGY);
+		final boolean specRegenObserved = lastSpecEnergy != -1
+			&& currentSpecEnergy > lastSpecEnergy
+			&& currentSpecEnergy - lastSpecEnergy <= 100;
 
-		if (client.getVarpValue(VarPlayerID.SA_ENERGY) == 1000)
+		if (currentSpecEnergy == 1000)
 		{
 			// The recharge doesn't tick when at 100%
+			ticksSinceSpecRegen = 0;
+		}
+		else if (specRegenObserved)
+		{
+			// Snap the ring back to empty when the client has observed a real spec regen this tick.
 			ticksSinceSpecRegen = 0;
 		}
 		else
 		{
 			ticksSinceSpecRegen = (ticksSinceSpecRegen + 1) % ticksPerSpecRegen;
 		}
+		lastSpecEnergy = currentSpecEnergy;
 		specialPercentage = ticksSinceSpecRegen / (double) ticksPerSpecRegen;
 
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/regenmeter/RegenMeterPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/regenmeter/RegenMeterPluginTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026, Eambo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.regenmeter;
+
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import net.runelite.api.Client;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.Skill;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.api.gameval.InventoryID;
+import net.runelite.api.gameval.VarPlayerID;
+import net.runelite.client.Notifier;
+import net.runelite.client.ui.overlay.OverlayManager;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RegenMeterPluginTest
+{
+	private static final int BR_LIGHTBEARER = 27870;
+
+	@Mock
+	@Bind
+	private Client client;
+
+	@Mock
+	@Bind
+	private OverlayManager overlayManager;
+
+	@Mock
+	@Bind
+	private Notifier notifier;
+
+	@Mock
+	@Bind
+	private RegenMeterOverlay overlay;
+
+	@Mock
+	@Bind
+	private RegenMeterConfig config;
+
+	@Inject
+	private RegenMeterPlugin plugin;
+
+	@Before
+	public void before()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+
+		when(client.getBoostedSkillLevel(Skill.HITPOINTS)).thenReturn(99);
+		when(client.getRealSkillLevel(Skill.HITPOINTS)).thenReturn(99);
+		when(config.showWhenNoChange()).thenReturn(true);
+	}
+
+	@Test
+	public void resetsSpecMeterWhenSpecEnergyRegens()
+	{
+		when(client.getVarpValue(VarPlayerID.SA_ENERGY)).thenReturn(600);
+
+		for (int i = 0; i < 25; i++)
+		{
+			plugin.onGameTick(new GameTick());
+		}
+
+		assertEquals(0.5d, plugin.getSpecialPercentage(), 0.001d);
+
+		when(client.getVarpValue(VarPlayerID.SA_ENERGY)).thenReturn(700);
+		plugin.onGameTick(new GameTick());
+
+		assertEquals(0d, plugin.getSpecialPercentage(), 0.001d);
+	}
+
+	@Test
+	public void recognizesLightbearerVariation()
+	{
+		ItemContainer equipment = mock(ItemContainer.class);
+		when(equipment.getItem(EquipmentInventorySlot.RING.getSlotIdx())).thenReturn(new Item(BR_LIGHTBEARER, 1));
+		plugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.WORN, equipment));
+
+		when(client.getVarpValue(VarPlayerID.SA_ENERGY)).thenReturn(0);
+		plugin.onGameTick(new GameTick());
+
+		assertEquals(1d / 25d, plugin.getSpecialPercentage(), 0.001d);
+	}
+}


### PR DESCRIPTION
## Summary
- reset the spec orb when passive special attack regeneration is actually observed from `SA_ENERGY`
- seed the last seen special energy value on startup to avoid false resyncs after enabling the plugin mid-cycle
- detect Lightbearer from the canonicalized ring item id so variations behave correctly
- add a targeted regression test for spec resync and Lightbearer variation handling

## Reproduction Steps:
- Wait until spec energy is about 60% filled
- Turn off the `Regeneration Meter` plugin
- Turn it back on after a few seconds
- Note that your spec energy will increase, out-of-sync with the orb

Repeat the same steps above with this fix in place, and the spec energy orb should be in sync on the next spec energy adjustment.

## Testing Done:

I tested this with both lightbearer and without using the repro steps above. This has been a random niggle of mine for a while and this *seems* to fix it in my testing, but I didn't comprehensively test every scenario (IE: Doom, NMZ) 

## Issue impact
- Fixes #19427
- Likely fixes #12323. This uses the same workaround suggested there: resync on observed `SA_ENERGY` increases instead of letting the spec meter free-run until 100%.
- Might fix #19794 if that report is the same underlying spec-meter desync outside of Lightbearer scenarios.