### PR TITLE
Updated Beginner Map Clue steps to better reflect the center tile of the dig area

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java
@@ -35,7 +35,7 @@ public class BeginnerMapClue extends MapClue implements LocationClueScroll
 	private static final ImmutableList<BeginnerMapClue> CLUES = ImmutableList.of(
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP01, new WorldPoint(3167, 3360, 0), MapClue.CHAMPIONS_GUILD),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP02, new WorldPoint(3290, 3373, 0), MapClue.VARROCK_EAST_MINE),
-		new BeginnerMapClue(InterfaceID.TRAIL_MAP03, new WorldPoint(3093, 3226, 0), MapClue.SOUTH_OF_DRAYNOR_BANK),
+		new BeginnerMapClue(InterfaceID.TRAIL_MAP03, new WorldPoint(3092, 3226, 0), MapClue.SOUTH_OF_DRAYNOR_BANK),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP06, new WorldPoint(3043, 3398, 0), MapClue.STANDING_STONES),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP11, new WorldPoint(3110, 3152, 0), MapClue.WIZARDS_TOWER_DIS)
 	);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java
@@ -33,7 +33,7 @@ import net.runelite.api.gameval.InterfaceID;
 public class BeginnerMapClue extends MapClue implements LocationClueScroll
 {
 	private static final ImmutableList<BeginnerMapClue> CLUES = ImmutableList.of(
-		new BeginnerMapClue(InterfaceID.TRAIL_MAP01, new WorldPoint(3166, 3361, 0), MapClue.CHAMPIONS_GUILD),
+		new BeginnerMapClue(InterfaceID.TRAIL_MAP01, new WorldPoint(3167, 3360, 0), MapClue.CHAMPIONS_GUILD),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP02, new WorldPoint(3290, 3373, 0), MapClue.VARROCK_EAST_MINE),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP03, new WorldPoint(3093, 3226, 0), MapClue.SOUTH_OF_DRAYNOR_BANK),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP06, new WorldPoint(3043, 3398, 0), MapClue.STANDING_STONES),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java
@@ -36,7 +36,7 @@ public class BeginnerMapClue extends MapClue implements LocationClueScroll
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP01, new WorldPoint(3167, 3360, 0), MapClue.CHAMPIONS_GUILD),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP02, new WorldPoint(3290, 3373, 0), MapClue.VARROCK_EAST_MINE),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP03, new WorldPoint(3092, 3226, 0), MapClue.SOUTH_OF_DRAYNOR_BANK),
-		new BeginnerMapClue(InterfaceID.TRAIL_MAP06, new WorldPoint(3043, 3398, 0), MapClue.STANDING_STONES),
+		new BeginnerMapClue(InterfaceID.TRAIL_MAP06, new WorldPoint(3043, 3399, 0), MapClue.STANDING_STONES),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP11, new WorldPoint(3110, 3152, 0), MapClue.WIZARDS_TOWER_DIS)
 	);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java
@@ -37,7 +37,7 @@ public class BeginnerMapClue extends MapClue implements LocationClueScroll
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP02, new WorldPoint(3290, 3373, 0), MapClue.VARROCK_EAST_MINE),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP03, new WorldPoint(3092, 3226, 0), MapClue.SOUTH_OF_DRAYNOR_BANK),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP06, new WorldPoint(3043, 3399, 0), MapClue.STANDING_STONES),
-		new BeginnerMapClue(InterfaceID.TRAIL_MAP11, new WorldPoint(3110, 3152, 0), MapClue.WIZARDS_TOWER_DIS)
+		new BeginnerMapClue(InterfaceID.TRAIL_MAP11, new WorldPoint(3109, 3153, 0), MapClue.WIZARDS_TOWER_DIS)
 	);
 
 	private final int widgetGroupID;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java
@@ -34,7 +34,7 @@ public class BeginnerMapClue extends MapClue implements LocationClueScroll
 {
 	private static final ImmutableList<BeginnerMapClue> CLUES = ImmutableList.of(
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP01, new WorldPoint(3166, 3361, 0), MapClue.CHAMPIONS_GUILD),
-		new BeginnerMapClue(InterfaceID.TRAIL_MAP02, new WorldPoint(3290, 3374, 0), MapClue.VARROCK_EAST_MINE),
+		new BeginnerMapClue(InterfaceID.TRAIL_MAP02, new WorldPoint(3290, 3373, 0), MapClue.VARROCK_EAST_MINE),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP03, new WorldPoint(3093, 3226, 0), MapClue.SOUTH_OF_DRAYNOR_BANK),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP06, new WorldPoint(3043, 3398, 0), MapClue.STANDING_STONES),
 		new BeginnerMapClue(InterfaceID.TRAIL_MAP11, new WorldPoint(3110, 3152, 0), MapClue.WIZARDS_TOWER_DIS)


### PR DESCRIPTION
Map Clue steps have a 3x3 dig area in reality. This updates the highlighted tiles by the plugin to accurately point to the center of that dig area