### PR TITLE
item prices: add ability to disable overlay for specific items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
@@ -96,4 +96,15 @@ public interface ItemPricesConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "disabledItems",
+		name = "Disabled items",
+		description = "Items to hide tooltips for. Format: item1, item2, item3 (supports * wildcard).",
+		position = 7
+	)
+	default String disabledItems()
+	{
+		return "";
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
@@ -26,6 +26,8 @@ package net.runelite.client.plugins.itemprices;
 
 import com.google.inject.Provides;
 import java.awt.Color;
+import java.util.Collections;
+import java.util.List;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.ItemComposition;
@@ -38,6 +40,7 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetUtil;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -45,6 +48,8 @@ import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.QuantityFormatter;
+import net.runelite.client.util.Text;
+import net.runelite.client.util.WildcardMatcher;
 
 @PluginDescriptor(
 	name = "Item Prices",
@@ -68,14 +73,27 @@ public class ItemPricesPlugin extends Plugin
 
 	private final StringBuilder itemStringBuilder = new StringBuilder();
 
+	private List<String> disabledItems = Collections.emptyList();
+
 	@Override
 	protected void startUp()
 	{
+		disabledItems = Text.fromCSV(config.disabledItems());
 	}
 
 	@Override
 	protected void shutDown()
 	{
+		disabledItems = Collections.emptyList();
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals("itemprices") && event.getKey().equals("disabledItems"))
+		{
+			disabledItems = Text.fromCSV(config.disabledItems());
+		}
 	}
 
 	@Provides
@@ -227,6 +245,11 @@ public class ItemPricesPlugin extends Plugin
 			return null;
 		}
 
+		if (isDisabled(itemDef.getName()))
+		{
+			return null;
+		}
+
 		int gePrice = 0;
 		int haPrice = 0;
 		int haProfit = 0;
@@ -305,6 +328,18 @@ public class ItemPricesPlugin extends Plugin
 		final String text = itemStringBuilder.toString();
 		itemStringBuilder.setLength(0);
 		return text;
+	}
+
+	private boolean isDisabled(String itemName)
+	{
+		for (String pattern : disabledItems)
+		{
+			if (WildcardMatcher.matches(pattern, itemName))
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private int calculateHAProfit(int haPrice, int gePrice)


### PR DESCRIPTION
# Description

A small update to the Item Prices plugin to allow users to disable the overlay for specific items. This is useful for items like potions or food, for which you typically only care about what they'll do for your stats, not what they're worth.

I referenced the Ground Items plugin for the implementation here.

# Functional verification

## prices still shown when an item is not disabled
<img width="509" height="1018" alt="item_prices_default" src="https://github.com/user-attachments/assets/f979c651-593d-4023-91e9-d67880fa5b45" />

## price overlay hidden when an item is disabled
<img width="509" height="1018" alt="item_prices_disabled" src="https://github.com/user-attachments/assets/4710b9a1-94c7-4b7b-aa64-b86ac5acd0ed" />

## price overlay hidden when an item is disabled via wildcard
<img width="509" height="1018" alt="item_prices_disabled_wildcard" src="https://github.com/user-attachments/assets/2a3f5c23-089e-41d3-a830-d6c867559834" />

## price overlay hidden when multiple items are listed
<img width="509" height="1018" alt="item_prices_disabled_multiple" src="https://github.com/user-attachments/assets/cc4c7fd9-3393-4f4b-8e36-6c637bc91be2" />

