### PR TITLE
Fix bank search shortcut handling

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -55,12 +55,14 @@ import net.runelite.api.events.MenuShouldLeftClick;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.api.events.ScriptPostFired;
 import net.runelite.api.events.ScriptPreFired;
+import net.runelite.api.events.WidgetClosed;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarClientID;
 import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.vars.InputType;
 import net.runelite.api.widgets.JavaScriptCallback;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
@@ -117,77 +119,131 @@ public class BankPlugin extends Plugin
 	private Multiset<Integer> itemQuantities; // bank item quantities for bank value search
 	private String searchString;
 	private ContainerPrices prices;
+	private boolean bankOpen;
+	private boolean sharedBankOpen;
+	private boolean seedVaultOpen;
+	private int searchHotkeyTypedKeyCode = KeyEvent.VK_UNDEFINED;
 
 	private final KeyListener searchHotkeyListener = new KeyListener()
 	{
 		@Override
 		public void keyTyped(KeyEvent e)
 		{
+			consumeSearchHotkeyTypedChar(e);
 		}
 
 		@Override
 		public void keyPressed(KeyEvent e)
 		{
 			Keybind keybind = config.searchKeybind();
-			if (keybind.matches(e))
+			if (!keybind.matches(e))
 			{
-				Widget bankContainer = client.getWidget(InterfaceID.Bankmain.ITEMS);
-				if (bankContainer != null && !bankContainer.isSelfHidden())
-				{
-					log.debug("Search hotkey pressed");
-					bankSearch.initSearch();
-					e.consume();
-				}
+				return;
+			}
 
-				Widget groupStorageSearchButton = client.getWidget(InterfaceID.SharedBank.SEARCH);
-				if (groupStorageSearchButton != null)
+			if (!isSearchableBankOpen() || isSearchInputOpen())
+			{
+				searchHotkeyTypedKeyCode = KeyEvent.VK_UNDEFINED;
+				return;
+			}
+
+			boolean hotkeyUsed = false;
+			Widget bankContainer = client.getWidget(InterfaceID.Bankmain.ITEMS);
+			if (bankOpen
+				&& bankContainer != null
+				&& !bankContainer.isSelfHidden())
+			{
+				log.debug("Search hotkey pressed");
+				bankSearch.initSearch();
+				hotkeyUsed = true;
+			}
+
+			Widget groupStorageSearchButton = client.getWidget(InterfaceID.SharedBank.SEARCH);
+			if (sharedBankOpen && groupStorageSearchButton != null && !groupStorageSearchButton.isSelfHidden())
+			{
+				log.debug("Search hotkey pressed");
+				clientThread.invoke(() ->
 				{
-					log.debug("Search hotkey pressed");
-					clientThread.invoke(() ->
+					Widget searchButton = client.getWidget(InterfaceID.SharedBank.SEARCH);
+					if (searchButton == null || searchButton.isHidden())
 					{
-						Widget searchButton = client.getWidget(InterfaceID.SharedBank.SEARCH);
-						if (searchButton == null || searchButton.isHidden())
-						{
-							return;
-						}
+						return;
+					}
 
-						Object[] searchToggleArgs = searchButton.getOnOpListener();
-						if (searchToggleArgs == null)
-						{
-							return;
-						}
-
-						client.createScriptEventBuilder(searchToggleArgs) // [clientscript,shared_bank_search_toggle]
-							.setOp(1)
-							.build()
-							.run();
-					});
-					e.consume();
-				}
-
-				Widget seedVaultSearchButton = client.getWidget(InterfaceID.SeedVault.SEARCH);
-				if (seedVaultSearchButton != null)
-				{
-					log.debug("Search hotkey pressed");
-					clientThread.invoke(() ->
+					Object[] searchToggleArgs = searchButton.getOnOpListener();
+					if (searchToggleArgs == null)
 					{
-						Widget searchButton = client.getWidget(InterfaceID.SeedVault.SEARCH);
-						if (searchButton == null || searchButton.isHidden())
-						{
-							return;
-						}
-						client.runScript(searchButton.getOnOpListener());
-					});
-					e.consume();
-				}
+						return;
+					}
+
+					client.createScriptEventBuilder(searchToggleArgs) // [clientscript,shared_bank_search_toggle]
+						.setOp(1)
+						.build()
+						.run();
+				});
+				hotkeyUsed = true;
+			}
+
+			Widget seedVaultSearchButton = client.getWidget(InterfaceID.SeedVault.SEARCH);
+			if (seedVaultOpen && seedVaultSearchButton != null && !seedVaultSearchButton.isSelfHidden())
+			{
+				log.debug("Search hotkey pressed");
+				clientThread.invoke(() ->
+				{
+					Widget searchButton = client.getWidget(InterfaceID.SeedVault.SEARCH);
+					if (searchButton == null || searchButton.isHidden())
+					{
+						return;
+					}
+					client.runScript(searchButton.getOnOpListener());
+				});
+				hotkeyUsed = true;
+			}
+
+			if (hotkeyUsed)
+			{
+				searchHotkeyTypedKeyCode = keybind.getKeyCode();
+				e.consume();
 			}
 		}
 
 		@Override
 		public void keyReleased(KeyEvent e)
 		{
+			searchHotkeyTypedKeyCode = KeyEvent.VK_UNDEFINED;
+		}
+
+		@Override
+		public void focusLost()
+		{
+			searchHotkeyTypedKeyCode = KeyEvent.VK_UNDEFINED;
 		}
 	};
+
+	private void consumeSearchHotkeyTypedChar(KeyEvent e)
+	{
+		int keyCode = searchHotkeyTypedKeyCode;
+		if (keyCode == KeyEvent.VK_UNDEFINED)
+		{
+			return;
+		}
+
+		searchHotkeyTypedKeyCode = KeyEvent.VK_UNDEFINED;
+		if (isSearchableBankOpen() && KeyEvent.getExtendedKeyCodeForChar(e.getKeyChar()) == keyCode)
+		{
+			e.consume();
+		}
+	}
+
+	private boolean isSearchableBankOpen()
+	{
+		return bankOpen || sharedBankOpen || seedVaultOpen;
+	}
+
+	private boolean isSearchInputOpen()
+	{
+		return isSearchableBankOpen() && client.getVarcIntValue(VarClientID.MESLAYERMODE) == InputType.SEARCH.getType();
+	}
 
 	@Provides
 	BankConfig getConfig(ConfigManager configManager)
@@ -199,6 +255,10 @@ public class BankPlugin extends Plugin
 	protected void startUp()
 	{
 		keyManager.registerKeyListener(searchHotkeyListener);
+		bankOpen = false;
+		sharedBankOpen = false;
+		seedVaultOpen = false;
+		searchHotkeyTypedKeyCode = KeyEvent.VK_UNDEFINED;
 	}
 
 	@Override
@@ -209,6 +269,10 @@ public class BankPlugin extends Plugin
 		forceRightClickFlag = false;
 		itemQuantities = null;
 		searchString = null;
+		bankOpen = false;
+		sharedBankOpen = false;
+		seedVaultOpen = false;
+		searchHotkeyTypedKeyCode = KeyEvent.VK_UNDEFINED;
 	}
 
 	@Subscribe
@@ -304,9 +368,48 @@ public class BankPlugin extends Plugin
 	@Subscribe
 	public void onWidgetLoaded(WidgetLoaded event)
 	{
-		if (event.getGroupId() == InterfaceID.SEED_VAULT && config.seedVaultValue())
+		switch (event.getGroupId())
 		{
-			clientThread.invokeLater(this::updateSeedVaultTotal);
+			case InterfaceID.BANKMAIN:
+				bankOpen = true;
+				break;
+			case InterfaceID.SHARED_BANK:
+				sharedBankOpen = true;
+				break;
+			case InterfaceID.SEED_VAULT:
+				seedVaultOpen = true;
+				if (config.seedVaultValue())
+				{
+					clientThread.invokeLater(this::updateSeedVaultTotal);
+				}
+				break;
+		}
+	}
+
+	@Subscribe
+	public void onWidgetClosed(WidgetClosed event)
+	{
+		if (!event.isUnload())
+		{
+			return;
+		}
+
+		switch (event.getGroupId())
+		{
+			case InterfaceID.BANKMAIN:
+				bankOpen = false;
+				break;
+			case InterfaceID.SHARED_BANK:
+				sharedBankOpen = false;
+				break;
+			case InterfaceID.SEED_VAULT:
+				seedVaultOpen = false;
+				break;
+		}
+
+		if (!isSearchableBankOpen())
+		{
+			searchHotkeyTypedKeyCode = KeyEvent.VK_UNDEFINED;
 		}
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/bank/BankPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/bank/BankPluginTest.java
@@ -29,22 +29,36 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.awt.event.KeyEvent;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.events.WidgetClosed;
+import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.gameval.InventoryID;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.ItemID;
+import net.runelite.api.gameval.VarClientID;
+import net.runelite.api.vars.InputType;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.Keybind;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.input.KeyListener;
+import net.runelite.client.input.KeyManager;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -62,6 +76,18 @@ public class BankPluginTest
 	@Mock
 	@Bind
 	private BankConfig bankConfig;
+
+	@Mock
+	@Bind
+	private BankSearch bankSearch;
+
+	@Mock
+	@Bind
+	private ClientThread clientThread;
+
+	@Mock
+	@Bind
+	private KeyManager keyManager;
 
 	@Inject
 	private BankPlugin bankPlugin;
@@ -149,5 +175,143 @@ public class BankPluginTest
 
 		assertTrue(prices.getHighAlchPrice() > Integer.MAX_VALUE);
 		assertTrue(prices.getGePrice() > Integer.MAX_VALUE);
+	}
+
+	@Test
+	public void testSearchHotkeyDoesNotTriggerWhileSearching()
+	{
+		KeyListener keyListener = registerSearchHotkeyListener();
+		loadWidget(InterfaceID.BANKMAIN);
+		when(bankConfig.searchKeybind()).thenReturn(new Keybind(KeyEvent.VK_F, 0));
+		when(client.getVarcIntValue(VarClientID.MESLAYERMODE)).thenReturn(InputType.SEARCH.getType());
+
+		KeyEvent event = mockKeyEvent(KeyEvent.VK_F);
+		keyListener.keyPressed(event);
+
+		verify(bankSearch, never()).initSearch();
+		verify(event, never()).consume();
+	}
+
+	@Test
+	public void testSearchHotkeyTriggersBankSearch()
+	{
+		KeyListener keyListener = registerSearchHotkeyListener();
+		loadWidget(InterfaceID.BANKMAIN);
+		when(bankConfig.searchKeybind()).thenReturn(new Keybind(KeyEvent.VK_F, 0));
+		when(client.getVarcIntValue(VarClientID.MESLAYERMODE)).thenReturn(InputType.NONE.getType());
+
+		Widget bankContainer = mock(Widget.class);
+		when(bankContainer.isSelfHidden()).thenReturn(false);
+		when(client.getWidget(InterfaceID.Bankmain.ITEMS)).thenReturn(bankContainer);
+
+		KeyEvent event = mockKeyEvent(KeyEvent.VK_F);
+		keyListener.keyPressed(event);
+
+		verify(bankSearch).initSearch();
+		verify(event).consume();
+	}
+
+	@Test
+	public void testSearchHotkeyConsumesOpeningTypedEvent()
+	{
+		KeyListener keyListener = registerSearchHotkeyListener();
+		loadWidget(InterfaceID.BANKMAIN);
+		when(bankConfig.searchKeybind()).thenReturn(new Keybind(KeyEvent.VK_S, 0));
+		when(client.getVarcIntValue(VarClientID.MESLAYERMODE)).thenReturn(InputType.NONE.getType());
+
+		Widget bankContainer = mock(Widget.class);
+		when(bankContainer.isSelfHidden()).thenReturn(false);
+		when(client.getWidget(InterfaceID.Bankmain.ITEMS)).thenReturn(bankContainer);
+
+		keyListener.keyPressed(mockKeyEvent(KeyEvent.VK_S));
+
+		KeyEvent typedEvent = mockTypedEvent('s');
+		keyListener.keyTyped(typedEvent);
+		verify(typedEvent).consume();
+
+		KeyEvent subsequentTypedEvent = mockTypedEvent('s');
+		keyListener.keyTyped(subsequentTypedEvent);
+		verify(subsequentTypedEvent, never()).consume();
+	}
+
+	@Test
+	public void testSearchHotkeyDoesNotLeavePendingConsumeOutsideBank()
+	{
+		KeyListener keyListener = registerSearchHotkeyListener();
+		loadWidget(InterfaceID.BANKMAIN);
+		when(bankConfig.searchKeybind()).thenReturn(new Keybind(KeyEvent.VK_S, 0));
+		when(client.getVarcIntValue(VarClientID.MESLAYERMODE)).thenReturn(InputType.NONE.getType());
+
+		Widget bankContainer = mock(Widget.class);
+		when(bankContainer.isSelfHidden()).thenReturn(false);
+		when(client.getWidget(InterfaceID.Bankmain.ITEMS)).thenReturn(bankContainer);
+
+		keyListener.keyPressed(mockKeyEvent(KeyEvent.VK_S));
+		closeWidget(InterfaceID.BANKMAIN);
+
+		KeyEvent typedEvent = mockTypedEvent('s');
+		keyListener.keyTyped(typedEvent);
+		verify(typedEvent, never()).consume();
+	}
+
+	@Test
+	public void testSearchHotkeyDoesNotConsumeClosedBank()
+	{
+		KeyListener keyListener = registerSearchHotkeyListener();
+		when(bankConfig.searchKeybind()).thenReturn(new Keybind(KeyEvent.VK_S, 0));
+
+		KeyEvent event = mockKeyEvent(KeyEvent.VK_S);
+		keyListener.keyPressed(event);
+
+		verify(bankSearch, never()).initSearch();
+		verify(event, never()).consume();
+	}
+
+	@Test
+	public void testSearchHotkeyDoesNotConsumeOutsideBank()
+	{
+		KeyListener keyListener = registerSearchHotkeyListener();
+		when(bankConfig.searchKeybind()).thenReturn(new Keybind(KeyEvent.VK_S, 0));
+
+		KeyEvent event = mockKeyEvent(KeyEvent.VK_S);
+		keyListener.keyPressed(event);
+
+		verify(bankSearch, never()).initSearch();
+		verify(event, never()).consume();
+	}
+
+	private KeyListener registerSearchHotkeyListener()
+	{
+		bankPlugin.startUp();
+		ArgumentCaptor<KeyListener> captor = ArgumentCaptor.forClass(KeyListener.class);
+		verify(keyManager).registerKeyListener(captor.capture());
+		return captor.getValue();
+	}
+
+	private void loadWidget(int groupId)
+	{
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(groupId);
+		bankPlugin.onWidgetLoaded(event);
+	}
+
+	private void closeWidget(int groupId)
+	{
+		bankPlugin.onWidgetClosed(new WidgetClosed(groupId, 0, true));
+	}
+
+	private static KeyEvent mockKeyEvent(int keyCode)
+	{
+		KeyEvent event = mock(KeyEvent.class);
+		when(event.getExtendedKeyCode()).thenReturn(keyCode);
+		when(event.getModifiersEx()).thenReturn(0);
+		return event;
+	}
+
+	private static KeyEvent mockTypedEvent(char keyChar)
+	{
+		KeyEvent event = mock(KeyEvent.class);
+		when(event.getKeyChar()).thenReturn(keyChar);
+		return event;
 	}
 }


### PR DESCRIPTION
## Summary

I use `s` for my search hotkey, and when searching for anything with `s` in it, the search box resets which is extremely frustrating (IE: Type S to open search --> type "fish" --> get "h" because after fi-s- caused a reset to search.

This changes the behaviour of the search to respect when it's already open, and to not reset.

I made this change based on personal expectations and frustrations - however I have since found that https://github.com/runelite/runelite/issues/14342#issuecomment-962089628 mentions this may actually be intended behaviour (you can restart search within search).

As such - this PR might not be wanted if so, please close as such. If, however, sentiment has changed since 2021 - hopefully this PR comes in useful :-)

- Track bank, shared bank, and seed vault interface lifecycle before honoring the bank search shortcut
- Ignore the shortcut while bank search input is already active so the bound key can be typed normally
- Consume only the paired typed event from opening search, preventing plain-letter shortcuts from seeding the search text
- Add BankPlugin tests for open, active-search, closed-bank, and opening-character cases

Fixes #14342
Addresses the bank-search portion of #13608.

## Testing
- `JAVA_HOME=/tmp/codex-jdk17/Contents/Home ./gradlew :client:test --tests net.runelite.client.plugins.bank.BankPluginTest`