### PR TITLE
idle notifier: fire idle when inventory becomes full while fishing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -36,6 +36,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.GameState;
 import net.runelite.api.Hitsplat;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.NPC;
 import net.runelite.api.NPCComposition;
 import net.runelite.api.Player;
@@ -47,9 +48,11 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.events.GraphicChanged;
 import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.InteractingChanged;
+import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.NpcChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.gameval.AnimationID;
+import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.SpotanimID;
 import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.gameval.VarbitID;
@@ -108,6 +111,7 @@ public class IdleNotifierPlugin extends Plugin
 	private Instant sixHourWarningTime;
 	private boolean ready;
 	private boolean lastInteractWasCombat;
+	private boolean fishingInventoryFull;
 	private static final int BUFF_BAR_NOT_DISPLAYED = -1;
 
 	@Provides
@@ -566,6 +570,34 @@ public class IdleNotifierPlugin extends Plugin
 	}
 
 	@Subscribe
+	public void onItemContainerChanged(ItemContainerChanged event)
+	{
+		if (event.getContainerId() != InventoryID.INV)
+		{
+			return;
+		}
+
+		if (lastInteract == null
+			|| lastInteract.getName() == null
+			|| !lastInteract.getName().contains(FISHING_SPOT))
+		{
+			return;
+		}
+
+		final ItemContainer inventory = event.getItemContainer();
+		if (inventory == null || inventory.count() < inventory.size())
+		{
+			return;
+		}
+
+		// Inventory is full while the fishing-spot NPC is still our interaction
+		// target. The OSRS client does not clear getInteracting() in this case,
+		// so checkInteractionIdle()'s null-target gate never fires. Set a flag
+		// the next idle check honours instead.
+		fishingInventoryFull = true;
+	}
+
+	@Subscribe
 	public void onGameTick(GameTick event)
 	{
 		final Player local = client.getLocalPlayer();
@@ -898,6 +930,24 @@ public class IdleNotifierPlugin extends Plugin
 			return false;
 		}
 
+		// Inventory filled while fishing — the fishing-spot NPC is still our
+		// interaction target so the null-target gate below would never fire.
+		if (fishingInventoryFull)
+		{
+			if (lastInteracting != null
+				&& Instant.now().compareTo(lastInteracting.plus(waitDuration)) >= 0
+				&& lastCombatCountdown == 0)
+			{
+				fishingInventoryFull = false;
+				lastInteract = null;
+				lastInteracting = null;
+				lastAnimation = -1;
+				lastAnimating = null;
+				return true;
+			}
+			return false;
+		}
+
 		final Actor interact = local.getInteracting();
 
 		if (interact == null)
@@ -1046,6 +1096,8 @@ public class IdleNotifierPlugin extends Plugin
 	private void resetTimers()
 	{
 		final Player local = client.getLocalPlayer();
+
+		fishingInventoryFull = false;
 
 		// Reset animation idle timer
 		lastAnimating = null;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -34,6 +34,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.GameState;
 import net.runelite.api.Hitsplat;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.NPC;
 import net.runelite.api.NPCComposition;
 import net.runelite.api.Player;
@@ -43,7 +44,9 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.InteractingChanged;
+import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.gameval.AnimationID;
+import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
@@ -302,6 +305,59 @@ public class IdleNotifierPluginTest
 		plugin.onGameTick(new GameTick());
 
 		verify(notifier).notify(Notification.ON, "You are now idle!");
+	}
+
+	@Test
+	public void testFishingInventoryFullFiresIdleEvenWhenSpotRemainsTarget()
+	{
+		// Player is fishing — interacting with the fishing-spot NPC and animating.
+		when(player.getInteracting()).thenReturn(fishingSpot);
+		when(player.getAnimation()).thenReturn(AnimationID.HUMAN_FISHING_CASTING);
+
+		AnimationChanged animationChanged = new AnimationChanged();
+		animationChanged.setActor(player);
+
+		plugin.onInteractingChanged(new InteractingChanged(player, fishingSpot));
+		plugin.onAnimationChanged(animationChanged);
+		plugin.onGameTick(new GameTick());
+
+		verify(notifier, never()).notify(anyString());
+
+		// Inventory becomes full while the fishing spot is still our target.
+		final ItemContainer inventory = mock(ItemContainer.class);
+		when(inventory.size()).thenReturn(28);
+		when(inventory.count()).thenReturn(28);
+		plugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.INV, inventory));
+
+		// Spot is still the interaction target — vanilla checkInteractionIdle would
+		// not fire. With the fix, the next tick fires the notification.
+		plugin.onGameTick(new GameTick());
+
+		verify(notifier).notify(Notification.ON, "You are now idle!");
+	}
+
+	@Test
+	public void testFishingPartialInventoryDoesNotFireIdle()
+	{
+		when(player.getInteracting()).thenReturn(fishingSpot);
+		when(player.getAnimation()).thenReturn(AnimationID.HUMAN_FISHING_CASTING);
+
+		AnimationChanged animationChanged = new AnimationChanged();
+		animationChanged.setActor(player);
+
+		plugin.onInteractingChanged(new InteractingChanged(player, fishingSpot));
+		plugin.onAnimationChanged(animationChanged);
+		plugin.onGameTick(new GameTick());
+
+		// 27 fish + 1 empty slot — not full.
+		final ItemContainer inventory = mock(ItemContainer.class);
+		when(inventory.size()).thenReturn(28);
+		when(inventory.count()).thenReturn(27);
+		plugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.INV, inventory));
+
+		plugin.onGameTick(new GameTick());
+
+		verify(notifier, never()).notify(anyString());
 	}
 
 	@Test


### PR DESCRIPTION
If you're AFK fishing and the inventory fills up, the idle notification doesn't fire while the fishing spot is still there. It only fires if the spot moves.

`checkInteractionIdle` only triggers when `Player.getInteracting()` is null. The fishing spot NPC is what you're interacting with while you fish. When the inventory fills you stop fishing, but the game client still has the fishing spot as your target, so `lastInteracting` gets refreshed every tick and the timer never elapses.

Adds a check on `ItemContainerChanged` for when the inventory hits 28/28 while interacting with a fishing spot, and sets a flag. `checkInteractionIdle` now also triggers on that flag, even when the target is still the spot. The flag gets cleared by `resetTimers()`, which already covers input activity, game state changes, and new interactions, so combat, spot despawn, and world hops behave the same as before.

Mining and woodcutting use GameObjects (rocks and trees) instead of NPCs and don't have this issue.

Two tests added: full inventory fires, partial inventory doesn't.
