### PR TITLE
Use a nicer background colour for inactive selected cells in Set<> configs

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/ui/laf/RuneLiteLAF.properties
+++ b/runelite-client/src/main/resources/net/runelite/client/ui/laf/RuneLiteLAF.properties
@@ -77,6 +77,8 @@ Component.borderColor=@BORDER
 
 CheckBox.arc=0
 
+List.selectionInactiveBackground=@selectionBackground
+
 MenuBar.background=@DARKER_GRAY
 MenuBar.border=0,0,0,0
 

--- a/runelite-client/src/main/resources/net/runelite/client/ui/laf/RuneLiteLAF.properties
+++ b/runelite-client/src/main/resources/net/runelite/client/ui/laf/RuneLiteLAF.properties
@@ -38,6 +38,7 @@
 @menuBackground=lighten(@background, 4%)
 @accentFocusColor=@MEDIUM_GRAY
 @selectionBackground=@MEDIUM_GRAY
+@selectionInactiveBackground=@MEDIUM_GRAY
 
 ButtonUI=net.runelite.client.ui.laf.RuneLiteButtonUI
 Button.arc=0


### PR DESCRIPTION
Before: 
<img width="229" height="170" alt="image" src="https://github.com/user-attachments/assets/784f8813-bcf2-442f-8dd3-289870dca7dd" />

After: 
<img width="230" height="171" alt="image" src="https://github.com/user-attachments/assets/644db518-9410-4aaa-bdbb-4c6a2beb4e6c" />

Flatlaf by default applies `spin(saturate(shade(@selectionBackground,70%),20%),-15)` to the `@selectionInactiveBackground` colour which turns `MEDIUM_GRAY` (77, 77, 77) to a very dark (28, 18, 21) colour.

This PR makes the inactive selected cells the same colour as when selecting them, but it might still want to be a different colour, just not as dark as on release.

I've only applied it to List elements instead of the global `@selectionInactiveBackground` as I'm not sure what else that might affect.