### PR TITLE
gpu: Orphan interface PBO before mapping

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -1369,10 +1369,6 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			lastCanvasWidth = canvasWidth;
 			lastCanvasHeight = canvasHeight;
 
-			glBindBuffer(GL_PIXEL_UNPACK_BUFFER, interfacePbo);
-			glBufferData(GL_PIXEL_UNPACK_BUFFER, canvasWidth * canvasHeight * 4L, GL_STREAM_DRAW);
-			glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
-
 			glBindTexture(GL_TEXTURE_2D, interfaceTexture);
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, canvasWidth, canvasHeight, 0, GL_BGRA, GL_UNSIGNED_BYTE, 0);
 			glBindTexture(GL_TEXTURE_2D, 0);
@@ -1384,6 +1380,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		final int height = bufferProvider.getHeight();
 
 		glBindBuffer(GL_PIXEL_UNPACK_BUFFER, interfacePbo);
+		glBufferData(GL_PIXEL_UNPACK_BUFFER, (long) width * height * Integer.BYTES, GL_STREAM_DRAW);
 		ByteBuffer interfaceBuf = glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY);
 		if (interfaceBuf != null)
 		{
@@ -1391,6 +1388,11 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 				.asIntBuffer()
 				.put(pixels, 0, width * height);
 			glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+		}
+		else
+		{
+			glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+			return;
 		}
 		glBindTexture(GL_TEXTURE_2D, interfaceTexture);
 		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, 0);


### PR DESCRIPTION
The UI is uploaded every frame through `GL_PIXEL_UNPACK_BUFFER`. The PBO storage is currently only reallocated when the canvas size changes, so mapping it can block if the previous frame's texture upload is still using the buffer.

Re-specifying the buffer before mapping lets the driver provide fresh storage for the next upload instead of waiting on the previous one.

In local testing this improved FPS by roughly 20% FPS while standing in the middle of Priff.

Tested on an AMD Radeon RX 6900 XT, driver 26.3.1.