### PR TITLE
loot tracker & mining: track rubium geodes/rocks/deposits

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -1172,6 +1172,10 @@ public class LootTrackerPlugin extends Plugin
 		{
 			countChangedItems(ItemID.DIRTY_ARROWTIPS, client.getBoostedSkillLevel(Skill.FLETCHING));
 		}
+		else if (message.equals("You crack open the rubium geode and obtain some rubium splinters."))
+		{
+			countChangedItems(ItemID.RUBIUM_GEODE, client.getBoostedSkillLevel(Skill.MINING));
+		}
 	}
 
 	private void countChangedItems(int itemId, Object metadata)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
@@ -75,7 +75,7 @@ public class MiningPlugin extends Plugin
 {
 	private static final Pattern MINING_PATTERN = Pattern.compile(
 		"You swing your pick at the " +
-			"(?:rock|star)" +
+			"(?:rock|star|deposit)" +
 			"(?:\\.|!)");
 
 	private static final int DAEYALT_ESSENCE_MINE_REGION = 14744;
@@ -318,6 +318,7 @@ public class MiningPlugin extends Plugin
 				case ObjectID.MY2ARM_SALTROCK_EMPTY: // Basalt etc
 				case ObjectID.PRIF_MINE_ROCKS1_EMPTY: // Trahaearn mine
 				case ObjectID.FOSSIL_ASHPILE_EMPTY:
+				case ObjectID.RUBIUMROCK1_EMPTY:
 				{
 					addRockRespawn(Rock.ROCK, WorldPoint.fromCoord(locCoord), ticks);
 					break;


### PR DESCRIPTION
### Loot tracker
- Track rubium geodes w/ Mining lvl.

According to the [poll blog](https://oldschool.runescape.wiki/w/Update:Sailing_-_Resources_%26_Skilling_Activities_Poll#Mining:_New_Ores!), the number of shards you get from cracking open a rubium geode scales with Mining level. The chat message is generic and does not contain the quantity.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/ea55affc-8b69-4865-8e37-585a0e8ad925" />

Test:

<img width="241" height="299" alt="image" src="https://github.com/user-attachments/assets/6195c4e3-e14c-47b8-9886-5cc2897e616b" />

### Mining
- Track sessions for rubium deposits (match "You swing your pick at the deposit.")
- Add respawn overlay for rubium rocks

Tests:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0ffa5e38-89de-41ef-8203-c24e93f06cfa" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/621afe3a-3b41-4274-87ce-7bd5f9201681" />