### PR TITLE
Key Remapping: add CTRL+M (world map) remap.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
@@ -298,4 +298,15 @@ public interface KeyRemappingConfig extends Config
 	{
 		return new ModifierlessKeybind(KeyEvent.VK_UNDEFINED, InputEvent.CTRL_DOWN_MASK);
 	}
+
+	@ConfigItem(
+		position = 22,
+		keyName = "worldMap",
+		name = "World map",
+		description = "The key which will replace ctrl+m to toggle the world map."
+	)
+	default ModifierlessKeybind worldMap()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_M, 0);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -26,6 +26,7 @@
 package net.runelite.client.plugins.keyremapping;
 
 import com.google.common.base.Strings;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -52,6 +53,7 @@ class KeyRemappingListener implements KeyListener
 	private ClientThread clientThread;
 
 	private final Map<Integer, Integer> modified = new HashMap<>();
+	private final Set<Integer> worldMapPressed = new HashSet<>();
 	private final Set<Character> blockedChars = new HashSet<>();
 
 	@Override
@@ -181,6 +183,18 @@ class KeyRemappingListener implements KeyListener
 					blockedChars.add(keyChar);
 				}
 			}
+			else if (!plugin.isDialogOpen() && config.worldMap().matches(e))
+			{
+				final char keyChar = e.getKeyChar();
+				worldMapPressed.add(e.getKeyCode());
+				e.setKeyCode(KeyEvent.VK_M);
+				e.setModifiers(e.getModifiers() | InputEvent.CTRL_MASK | InputEvent.CTRL_DOWN_MASK);
+				e.setKeyChar(KeyEvent.CHAR_UNDEFINED);
+				if (keyChar != KeyEvent.CHAR_UNDEFINED)
+				{
+					blockedChars.add(keyChar);
+				}
+			}
 
 			switch (e.getKeyCode())
 			{
@@ -240,6 +254,12 @@ class KeyRemappingListener implements KeyListener
 		if (mappedKeyCode != null)
 		{
 			e.setKeyCode(mappedKeyCode);
+			e.setKeyChar(KeyEvent.CHAR_UNDEFINED);
+		}
+		else if (worldMapPressed.remove(keyCode))
+		{
+			e.setKeyCode(KeyEvent.VK_M);
+			e.setModifiers(e.getModifiers() | InputEvent.CTRL_MASK | InputEvent.CTRL_DOWN_MASK);
 			e.setKeyChar(KeyEvent.CHAR_UNDEFINED);
 		}
 	}


### PR DESCRIPTION
To be clear! I do not usually work with Java and this is entirely AI generated code off my prompt.

This needs testing and may need additional contributions (if its even possible to get working).

This is basically attempting to give the user the option to rebind the CTRL+M to M when opening the map - it was a complaint from a friend so figured I'd give Claude a whack at it.