### PR TITLE
Adding QoL changes to the script inspector

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/ScriptInspector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/ScriptInspector.java
@@ -31,8 +31,6 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -513,7 +511,7 @@ public class ScriptInspector extends DevToolsFrame
 			javax.swing.JPopupMenu popup = new javax.swing.JPopupMenu();
 			javax.swing.JMenuItem blacklistOpt = new javax.swing.JMenuItem(blacklistStr);
 			blacklistOpt.addActionListener(action -> {
-				if (isBlacklisted) 
+				if(isBlacklisted) 
 				{
 					blacklist.remove(scriptId);
 				}
@@ -526,7 +524,7 @@ public class ScriptInspector extends DevToolsFrame
 			popup.add(blacklistOpt);
 			javax.swing.JMenuItem highlightOpt = new javax.swing.JMenuItem(highlightStr);
 			highlightOpt.addActionListener(action -> {
-				if (isHighlighted) 
+				if(isHighlighted) 
 				{
 					highlights.remove(scriptId);
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/ScriptInspector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/ScriptInspector.java
@@ -31,6 +31,8 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -237,7 +239,7 @@ public class ScriptInspector extends DevToolsFrame
 		listModel = new DefaultListModel<>();
 		changeState(ListState.BLACKLIST);
 		jList = new JList<>(listModel);
-		jList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		jList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 		JScrollPane listScrollPane = new JScrollPane(jList);
 
 		final JButton blacklistButton = new JButton("Blacklist");
@@ -437,8 +439,8 @@ public class ScriptInspector extends DevToolsFrame
 			return;
 		}
 
-		int script = listModel.get(index);
-		getSet().remove(script);
+		Set<Integer> set = getSet();
+		jList.getSelectedValuesList().forEach(set::remove);
 		refreshList();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/ScriptInspector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/ScriptInspector.java
@@ -510,8 +510,9 @@ public class ScriptInspector extends DevToolsFrame
 
 			javax.swing.JPopupMenu popup = new javax.swing.JPopupMenu();
 			javax.swing.JMenuItem blacklistOpt = new javax.swing.JMenuItem(blacklistStr);
-			blacklistOpt.addActionListener(action -> {
-				if(isBlacklisted) 
+			blacklistOpt.addActionListener(action ->
+			{
+				if (isBlacklisted)
 				{
 					blacklist.remove(scriptId);
 				}
@@ -523,8 +524,9 @@ public class ScriptInspector extends DevToolsFrame
 			});
 			popup.add(blacklistOpt);
 			javax.swing.JMenuItem highlightOpt = new javax.swing.JMenuItem(highlightStr);
-			highlightOpt.addActionListener(action -> {
-				if(isHighlighted) 
+			highlightOpt.addActionListener(action ->
+			{
+				if (isHighlighted)
 				{
 					highlights.remove(scriptId);
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/ScriptInspector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/ScriptInspector.java
@@ -381,6 +381,17 @@ public class ScriptInspector extends DevToolsFrame
 			tree.setRootVisible(true);
 			tree.setShowsRootHandles(true);
 			tree.collapsePath(new TreePath(treeNode));
+			tree.addMouseListener(new java.awt.event.MouseAdapter()
+			{
+				@Override
+				public void mouseReleased(java.awt.event.MouseEvent e)
+				{
+					if (e.isPopupTrigger())
+					{
+						showRightClickMenu(e, tree);
+					}
+				}
+			});
 
 			ScriptTreeNode highlightNode = findHighlightPathNode(treeNode);
 
@@ -482,5 +493,50 @@ public class ScriptInspector extends DevToolsFrame
 		}
 
 		return null;
+	}
+
+	private void showRightClickMenu(java.awt.event.MouseEvent e, JTree targetTree)
+	{
+		TreePath path = targetTree.getPathForLocation(e.getX(), e.getY());
+		if (path != null)
+		{
+			targetTree.setSelectionPath(path);
+			int scriptId = ((ScriptTreeNode) path.getLastPathComponent()).getScriptId();
+
+			boolean isBlacklisted = blacklist.contains(scriptId);
+			boolean isHighlighted = highlights.contains(scriptId);
+			String blacklistStr = (isBlacklisted ? "Remove from blacklist " : "Blacklist ") + scriptId;
+			String highlightStr = (isHighlighted ? "Remove from highlights " : "Highlight ") + scriptId;
+
+			javax.swing.JPopupMenu popup = new javax.swing.JPopupMenu();
+			javax.swing.JMenuItem blacklistOpt = new javax.swing.JMenuItem(blacklistStr);
+			blacklistOpt.addActionListener(action -> {
+				if (isBlacklisted) 
+				{
+					blacklist.remove(scriptId);
+				}
+				else
+				{
+					blacklist.add(scriptId);
+				}
+				refreshList();
+			});
+			popup.add(blacklistOpt);
+			javax.swing.JMenuItem highlightOpt = new javax.swing.JMenuItem(highlightStr);
+			highlightOpt.addActionListener(action -> {
+				if (isHighlighted) 
+				{
+					highlights.remove(scriptId);
+				}
+				else
+				{
+					highlights.add(scriptId);
+				}
+				refreshList();
+			});
+			popup.add(highlightOpt);
+
+			popup.show(e.getComponent(), e.getX(), e.getY());
+		}
 	}
 }


### PR DESCRIPTION
I have recently started developing and publishing a couple plugins that rely on detecting scripts firing to function and using the script inspector was a bit of a rough experience. 🐈

This PR adds some QoL changes to the script inspector:
- Added a right click popup to add/remove scripts from the log to the blacklist or highlights
- Added the option to select multiple scrips from the right side panel to delete all at once

https://github.com/user-attachments/assets/2d7c712f-9262-49d4-9d5e-b377920538d5

> I did see the open PR request with a similar name but as the author had not replied in 2 years i decided it would be best to create a new one.

