### PR TITLE
rl-client: fix insets changing window sizes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -1416,6 +1416,7 @@ public class ClientUI
 		private int prevState;
 		private int previousContentWidth;
 		private boolean doingLayout;
+		private Insets previousFrameInsets;
 
 		@Override
 		public void addLayoutComponent(String name, Component comp)
@@ -1477,6 +1478,24 @@ public class ClientUI
 
 		private void layout(Container content, boolean forceSizingClient)
 		{
+			Insets frameInsets = frame.getInsets();
+
+			if (previousFrameInsets != null && !previousFrameInsets.equals(frameInsets)
+				&& (frame.getExtendedState() & Frame.MAXIMIZED_BOTH) == 0)
+			{
+				int dw = (frameInsets.left + frameInsets.right) - (previousFrameInsets.left + previousFrameInsets.right);
+				int dh = (frameInsets.top + frameInsets.bottom) - (previousFrameInsets.top + previousFrameInsets.bottom);
+				if (dw != 0 || dh != 0)
+				{
+					log.debug("Frame insets changed from {} to {}, adjusting frame size by ({}, {})",
+						previousFrameInsets, frameInsets, dw, dh);
+					previousFrameInsets = (Insets) frameInsets.clone();
+					frame.setSize(frame.getWidth() + dw, frame.getHeight() + dh);
+					return;
+				}
+			}
+			previousFrameInsets = (Insets) frameInsets.clone();
+
 			int changed = prevState ^ frame.getExtendedState();
 			prevState = frame.getExtendedState();
 
@@ -1559,6 +1578,8 @@ public class ClientUI
 			}
 
 			log.trace("finishing layout - content={} client={} sidebar={} frame={}", content.getWidth(), client.getWidth(), sidebar.getWidth(), frame.getWidth());
+			log.trace("bounds and insets - frameBounds={}, frameInsets={}, contentSize={}, clientSize={}",
+				frame.getBounds(), frameInsets, content.getSize(), client.getSize());
 		}
 
 		private Dimension size(Container content, Function<Component, Dimension> sizer)


### PR DESCRIPTION
Fixes #17612 I ended up installing jdk and trying to build and log the changes of the resize bug. Some weirdness keeps happening with the insets and in my case the frame insets get changed at some point causing the clientSize to increase to 1930x1082

```
2026-05-26 17:52:10 EEST [AWT-EventQueue-0] INFO  net.runelite.client.ui.ClientUI - Skipping layout because decorated frame insets are not yet initialized (bounds=java.awt.Rectangle[x=3840,y=1080,width=0,height=0])
2026-05-26 17:52:10 EEST [main] INFO  n.r.client.discord.DiscordService - Initializing Discord RPC service.
2026-05-26 17:52:11 EEST [main] INFO  net.runelite.client.RuneLite - Client initialization took 2929ms. Uptime: 3283ms
2026-05-26 17:52:11 EEST [AWT-EventQueue-0] INFO  net.runelite.client.ui.ClientUI - Layout settled: frameBounds=java.awt.Rectangle[x=3840,y=1080,width=1961,height=533], frameInsets=java.awt.Insets[top=25,left=5,bottom=5,right=5], contentSize=java.awt.Dimension[width=1951,height=503], clientSize=java.awt.Dimension[width=1920,height=503]
2026-05-26 17:52:11 EEST [AWT-EventQueue-0] INFO  net.runelite.client.ui.ClientUI - Layout settled: frameBounds=java.awt.Rectangle[x=3840,y=1080,width=1961,height=533], frameInsets=java.awt.Insets[top=25,left=5,bottom=5,right=5], contentSize=java.awt.Dimension[width=1951,height=503], clientSize=java.awt.Dimension[width=1920,height=503]
2026-05-26 17:52:11 EEST [AWT-EventQueue-0] INFO  net.runelite.client.ui.ClientUI - Layout settled: frameBounds=java.awt.Rectangle[x=2110,y=590,width=1961,height=1110], frameInsets=java.awt.Insets[top=25,left=5,bottom=5,right=5], contentSize=java.awt.Dimension[width=1951,height=1080], clientSize=java.awt.Dimension[width=1920,height=1080]
2026-05-26 17:52:11 EEST [AWT-EventQueue-0] INFO  net.runelite.client.ui.ClientUI - Layout settled: frameBounds=java.awt.Rectangle[x=2110,y=590,width=1961,height=1110], frameInsets=java.awt.Insets[top=25,left=5,bottom=5,right=5], contentSize=java.awt.Dimension[width=1951,height=1080], clientSize=java.awt.Dimension[width=1920,height=1080]
2026-05-26 17:52:11 EEST [AWT-EventQueue-0] INFO  net.runelite.client.ui.ClientUI - Layout settled: frameBounds=java.awt.Rectangle[x=2110,y=590,width=1961,height=1110], frameInsets=java.awt.Insets[top=28,left=0,bottom=0,right=0], contentSize=java.awt.Dimension[width=1961,height=1082], clientSize=java.awt.Dimension[width=1930,height=1082]
2026-05-26 17:52:11 EEST [AWT-EventQueue-0] INFO  net.runelite.client.ui.ClientUI - Layout settled: frameBounds=java.awt.Rectangle[x=2110,y=590,width=1961,height=1110], frameInsets=java.awt.Insets[top=28,left=0,bottom=0,right=0], contentSize=java.awt.Dimension[width=1961,height=1082], clientSize=java.awt.Dimension[width=1930,height=1082]
2026-05-26 17:52:11 EEST [AWT-EventQueue-0] INFO  net.runelite.client.ui.ClientUI - Layout settled: frameBounds=java.awt.Rectangle[x=2110,y=590,width=1961,height=1110], frameInsets=java.awt.Insets[top=28,left=0,bottom=0,right=0], contentSize=java.awt.Dimension[width=1961,height=1082], clientSize=java.awt.Dimension[width=1930,height=1082]
2026-05-26 17:52:23 EEST [AWT-EventQueue-0] INFO  net.runelite.client.ui.ClientUI - Layout settled: frameBounds=java.awt.Rectangle[x=2110,y=590,width=2203,height=1110], frameInsets=java.awt.Insets[top=28,left=0,bottom=0,right=0], contentSize=java.awt.Dimension[width=2203,height=1082], clientSize=java.awt.Dimension[width=1930,height=1082]
2026-05-26 17:52:23 EEST [AWT-EventQueue-0] INFO  net.runelite.client.ui.ClientUI - Layout settled: frameBounds=java.awt.Rectangle[x=2110,y=590,width=2203,height=1110], frameInsets=java.awt.Insets[top=28,left=0,bottom=0,right=0], contentSize=java.awt.Dimension[width=2203,height=1082], clientSize=java.awt.Dimension[width=1930,height=1082]
2026-05-26 17:52:24 EEST [AWT-EventQueue-0] INFO  net.runelite.client.ui.ClientUI - Layout settled: frameBounds=java.awt.Rectangle[x=2110,y=590,width=2203,height=1110], frameInsets=java.awt.Insets[top=28,left=0,bottom=0,right=0], contentSize=java.awt.Dimension[width=2203,height=1082], clientSize=java.awt.Dimension[width=1930,height=1082]
```

Adding the Frame insets and tracking them when they change and adjusting the frame size when the change happens so window size stays at whatever it's set to.