### PR TITLE
itemstats: Add T-Bone steak

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
@@ -131,6 +131,7 @@ public class ItemStatChanges
 		add(range(food(7), food(10)), ItemID.TBW_SPIDER_ON_STICK_COOKED, ItemID.TBW_SPIDER_ON_SHAFT_COOKED);
 		add(combo(food(8), food(6)), ItemID.GRAAHK_COOKED);
 		add(combo(food(9), food(8)), ItemID.KYATT_COOKED);
+		add(combo(food(9), boost(STRENGTH, 2)), ItemID.TBONE_STEAK);
 		add(combo(food(11), food(8)), ItemID.FENNECFOX_COOKED);
 		add(combo(food(13), food(10), heal(RUN_ENERGY, 10)), ItemID.DASHINGKEBBIT_COOKED);
 		add(combo(food(12), food(9)), ItemID.ANTELOPESUN_COOKED);


### PR DESCRIPTION
Adds Cooked t-bone steak to itemstats. Tested with status bar restore & mouseover tooltip.

<img width="277" height="282" alt="image" src="https://github.com/user-attachments/assets/c302d769-297d-498b-be2e-484d1137d37d" />
