### PR TITLE
xpupdater: Fix fetchXp guard flag

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpupdater/XpUpdaterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpupdater/XpUpdaterPlugin.java
@@ -126,8 +126,8 @@ public class XpUpdaterPlugin extends Plugin
 			if (local != null)
 			{
 				lastDisplayName = local.getName();
+				fetchXp = false;
 			}
-			fetchXp = false;
 		}
 	}
 


### PR DESCRIPTION
The fetchXp flag is set to true on startup, which is then used as a guard in the onGameTick method to determine whether to update the local state with the current display name and total xp.

Occasionally, client.getLocalPlayer() will return null so the localDisplayName never gets set and is then skipped perpetually since the fetchXp flag was flipped back to false regardless of whether the lastDisplayName was set. This PR just moves the fetchXp flag into the localPlayer != null check to ensure the displayName is always set.