### PR TITLE
Add a default `SnapCorner` to the top right of the inventory for resizable classic and modern

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayPosition.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayPosition.java
@@ -61,6 +61,10 @@ public enum OverlayPosition
 	 */
 	ABOVE_CHATBOX_RIGHT,
 	/**
+	 * Place overlay directly above right side of inventory
+	 */
+	ABOVE_INVENTORY_RIGHT,
+	/**
 	 * Place overlay in the top right most area possible
 	 */
 	CANVAS_TOP_RIGHT,

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -870,6 +870,7 @@ public class OverlayRenderer extends MouseAdapter
 		{
 			snapCorners.aboveChatboxRight.setPosition(snapCorners.bottomRight.getPositionX(), snapCorners.bottomRight.getPositionY());
 			snapCorners.canvasTopRight.setPosition(snapCorners.topRight.getPositionX(), snapCorners.topRight.getPositionY());
+			snapCorners.aboveInventoryRight.setPosition(snapCorners.bottomRight.getPositionX(), snapCorners.bottomRight.getPositionY());
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -755,6 +755,7 @@ public class OverlayRenderer extends MouseAdapter
 					overlayPosition = OverlayPosition.TOP_RIGHT;
 					break;
 				case ABOVE_CHATBOX_RIGHT:
+				case ABOVE_INVENTORY_RIGHT:
 					overlayPosition = OverlayPosition.BOTTOM_RIGHT;
 					break;
 			}
@@ -828,6 +829,42 @@ public class OverlayRenderer extends MouseAdapter
 		{
 			snapCorners.aboveChatboxRight.setPosition(viewportBounds.x + chatboxBounds.width - BORDER, bottomLeftY);
 			snapCorners.canvasTopRight.setPosition((int) client.getRealDimensions().getWidth(), 0);
+
+			final Dimension realDimensions = client.getRealDimensions();
+			int canvasRight = realDimensions.width;
+			int canvasBottom = realDimensions.height;
+			if (client.getVarbitValue(VarbitID.RESIZABLE_STONE_ARRANGEMENT) == 1)
+			{
+				Widget sideContainer = client.getWidget(InterfaceID.ToplevelPreEoc.SIDE_CONTAINER);
+				Widget tabs1 = client.getWidget(InterfaceID.ToplevelPreEoc.SIDE_STATIC_LAYER);
+				Widget tabs2 = client.getWidget(InterfaceID.ToplevelPreEoc.SIDE_MOVABLE_LAYER);
+				if (tabs1 != null)
+				{
+					int y = canvasBottom;
+					boolean inventoryOpen = sideContainer != null && !sideContainer.isHidden();
+					if (inventoryOpen)
+					{
+						y -= sideContainer.getHeight();
+					}
+					y -= tabs1.getHeight();
+					// movable tab layer only adds height once it has wrapped to its own row above the static
+					// one (larger OriginalY = higher up, as these are anchored from the panel bottom)
+					if (tabs2 != null && tabs2.getOriginalY() > tabs1.getOriginalY())
+					{
+						y -= tabs2.getHeight();
+					}
+					snapCorners.aboveInventoryRight.setPosition(canvasRight - BORDER, y - BORDER);
+				}
+			}
+			else
+			{
+				Widget sideMenu = client.getWidget(InterfaceID.ToplevelOsrsStretch.SIDE_MENU);
+				if (sideMenu != null)
+				{
+					int y = canvasBottom - sideMenu.getHeight();
+					snapCorners.aboveInventoryRight.setPosition(canvasRight - BORDER, y - BORDER);
+				}
+			}
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/SnapCorners.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/SnapCorners.java
@@ -29,7 +29,7 @@ import java.util.Collection;
 
 class SnapCorners
 {
-	final SnapCorner topLeft, topCenter, topRight, bottomLeft, bottomRight, aboveChatboxRight, canvasTopRight;
+	final SnapCorner topLeft, topCenter, topRight, bottomLeft, bottomRight, aboveChatboxRight, canvasTopRight, aboveInventoryRight;
 
 	SnapCorners()
 	{
@@ -40,6 +40,7 @@ class SnapCorners
 		this.bottomRight = new SnapCorner(OverlayPosition.BOTTOM_RIGHT, SnapCorner.ALIGNMENT_RIGHT | SnapCorner.ALIGNMENT_BOTTOM | SnapCorner.EXPAND_LEFT);
 		this.aboveChatboxRight = new SnapCorner(OverlayPosition.ABOVE_CHATBOX_RIGHT, SnapCorner.ALIGNMENT_RIGHT | SnapCorner.ALIGNMENT_BOTTOM | SnapCorner.EXPAND_UP);
 		this.canvasTopRight = new SnapCorner(OverlayPosition.CANVAS_TOP_RIGHT, SnapCorner.ALIGNMENT_RIGHT | SnapCorner.EXPAND_DOWN);
+		this.aboveInventoryRight = new SnapCorner(OverlayPosition.ABOVE_INVENTORY_RIGHT, SnapCorner.ALIGNMENT_RIGHT | SnapCorner.ALIGNMENT_BOTTOM | SnapCorner.EXPAND_UP);
 	}
 
 	SnapCorner forPosition(OverlayPosition overlayPosition)
@@ -60,6 +61,8 @@ class SnapCorners
 				return aboveChatboxRight;
 			case CANVAS_TOP_RIGHT:
 				return canvasTopRight;
+			case ABOVE_INVENTORY_RIGHT:
+				return aboveInventoryRight;
 			default:
 				throw new IllegalArgumentException();
 		}
@@ -67,6 +70,6 @@ class SnapCorners
 
 	Collection<SnapCorner> getSnapCorners()
 	{
-		return Arrays.asList(topLeft, topCenter, topRight, bottomLeft, bottomRight, aboveChatboxRight, canvasTopRight);
+		return Arrays.asList(topLeft, topCenter, topRight, bottomLeft, bottomRight, aboveChatboxRight, canvasTopRight, aboveInventoryRight);
 	}
 }


### PR DESCRIPTION
Proposing this as a default as it has been specifically requested many times, see:
https://github.com/runelite/runelite/issues/13477
https://github.com/runelite/runelite/issues/10793
https://github.com/runelite/runelite/issues/11491
https://github.com/runelite/runelite/issues/12042
https://github.com/runelite/runelite/issues/12216
https://github.com/runelite/runelite/issues/12908


Looks like:

https://github.com/user-attachments/assets/74e9a8af-6083-4d8b-b082-1c5714e99001


https://github.com/user-attachments/assets/42a898e4-4cdf-4d83-bd31-3fbae0cc10d6

(I just desperately want to swap to burning claws, click spec, and then not have to move my mouse much to re equip my defender)
