### PR TITLE
itemstats: add option to show equipment stats only when bank is open

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -113,6 +113,16 @@ public interface ItemStatConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "equipmentStatsOnlyInBank",
+			name = "Equipment stats only in bank",
+			description = "Only enables tooltips for equipment items when the bank is open."
+	)
+	default boolean equipmentStatsOnlyInBank()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "alwaysShowBaseStats",
 		name = "Always show base stats",
 		description = "Always include the base items stats in the tooltip."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -185,7 +185,10 @@ public class ItemStatOverlay extends Overlay
 			}
 		}
 
-		if (config.equipmentStats())
+		final Widget bankWidget = client.getWidget(InterfaceID.Bankmain.ITEMS);
+		final boolean isBankOpen = bankWidget != null && !bankWidget.isSelfHidden();
+
+		if (config.equipmentStats() && (!config.equipmentStatsOnlyInBank() || isBankOpen))
 		{
 			final ItemStats stats = itemManager.getItemStats(itemId);
 


### PR DESCRIPTION
Equipment stat tooltips can obscure the inventory during combat when hovering over gear or weapons. This adds a config option "Equipment stats only in bank" that suppresses equipment stat tooltips unless the bank is currently open, allowing players to freely hover inventory items during combat without the overlay getting in the way.
<img width="759" height="717" alt="image" src="https://github.com/user-attachments/assets/84f4a290-769b-4d61-ada7-f85f3578722b" />


