### PR TITLE
Fix location coordinates for cryptic clues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -554,7 +554,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_CLUE_HARD_RIDDLE029)
 			.text("And so on, and so on, and so on. Walking from the land of many unimportant things leads to a choice of paths.")
-			.location(new WorldPoint(2591, 3879, 0))
+			.location(new WorldPoint(2592, 3879, 0))
 			.solution("Dig on Etceteria next to the Evergreen tree in front of the castle walls.")
 			.build(),
 		CrypticClue.builder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -1641,7 +1641,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_CLUE_MASTER)
 			.text("A massive battle rages beneath so be careful when you dig by the large broken crossbow.")
-			.location(new WorldPoint(2927, 3761, 0))
+			.location(new WorldPoint(2927, 3763, 0))
 			.solution("NE of the God Wars Dungeon entrance, climb the rocky handholds & dig by large crossbow.")
 			.build(),
 		CrypticClue.builder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -1291,7 +1291,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_CLUE_MASTER)
 			.text("If you're feeling brave, dig beneath the dragon's eye.")
-			.location(new WorldPoint(2410, 4714, 0))
+			.location(new WorldPoint(2409, 4715, 0))
 			.solution("Dig below the mossy rock under the Viyeldi caves (Legend's Quest). Items needed: Pickaxe, unpowered orb, lockpick, spade, any charge orb spell, and either 79 agility or an axe and machete. With 96 agility no items are needed.")
 			.build(),
 		CrypticClue.builder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -1505,7 +1505,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_CLUE_MASTER)
 			.text("South of a river in a town surrounded by the undead, what lies beneath the furnace?")
-			.location(new WorldPoint(2857, 2966, 0))
+			.location(new WorldPoint(2857, 2965, 0))
 			.solution("Dig in front of the Shilo Village furnace.")
 			.build(),
 		CrypticClue.builder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -1912,7 +1912,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_CLUE_MASTER)
 			.text("Elvish onions.")
-			.location(new WorldPoint(3303, 6092, 0))
+			.location(new WorldPoint(3303, 6091, 0))
 			.solution("Dig in the onion patch east of the Prifddinas allotments.")
 			.build(),
 		CrypticClue.builder()


### PR DESCRIPTION
This is off 1 tile to the west as mentioned here: https://github.com/Daniel-Tudose/True-Clue-Dig-Locations/issues/13#issue-4529346668
This centers the tile, moving the indicator 1 tile east