### PR TITLE
discord: add opt-in username and world display

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
@@ -159,4 +159,26 @@ public interface DiscordConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showUsername",
+		name = "Username",
+		description = "Show your username in your Discord rich presence.",
+		position = 11
+	)
+	default boolean showUsername()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "showWorld",
+		name = "World",
+		description = "Show the world you are playing on in your Discord rich presence.",
+		position = 12
+	)
+	default boolean showWorld()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -37,6 +37,8 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
 import net.runelite.client.discord.DiscordPresence;
 import net.runelite.client.discord.DiscordService;
 
@@ -57,6 +59,7 @@ class DiscordState
 	private final List<EventWithTime> events = new ArrayList<>();
 	private final DiscordService discordService;
 	private final DiscordConfig config;
+	private final Client client;
 	private final String runeliteTitle;
 	private final String runeliteVersion;
 	private DiscordPresence lastPresence;
@@ -66,6 +69,7 @@ class DiscordState
 	private DiscordState(
 		final DiscordService discordService,
 		final DiscordConfig config,
+		final Client client,
 		@Named("runelite.title") final String runeliteTitle,
 		@Named("runelite.version") final String runeliteVersion,
 		@Named("safeMode") boolean safeMode
@@ -73,6 +77,7 @@ class DiscordState
 	{
 		this.discordService = discordService;
 		this.config = config;
+		this.client = client;
 		this.runeliteTitle = runeliteTitle;
 		this.runeliteVersion = runeliteVersion;
 		this.safeMode = safeMode;
@@ -175,6 +180,35 @@ class DiscordState
 		if (safeMode)
 		{
 			largeImageTooltipText.append(" (safe mode)");
+		}
+
+		if (config.showWorld() && client.getGameState() == GameState.LOGGED_IN)
+		{
+			final int world = client.getWorld();
+			if (state == null || state.isEmpty())
+			{
+				state = "World " + world;
+			}
+			else
+			{
+				state = state + " (W" + world + ")";
+			}
+		}
+
+		if (config.showUsername() && client.getLocalPlayer() != null)
+		{
+			final String name = client.getLocalPlayer().getName();
+			if (name != null && !name.isEmpty())
+			{
+				if (details == null || details.isEmpty())
+				{
+					details = name;
+				}
+				else
+				{
+					details = name + " | " + details;
+				}
+			}
 		}
 
 		final DiscordPresence.DiscordPresenceBuilder presenceBuilder = DiscordPresence.builder()


### PR DESCRIPTION
Adds two opt-in config options to the Discord plugin, both disabled by default.
Useful for players who want friends or clan members to see who they are and which
world they are on without needing to ask.

- **Username** — displays your OSRS username in the Discord rich presence details line (e.g. "Zezima | Training Attack", or just "Zezima" when idle)

<img width="268" height="114" alt="DiscordUsernameEnabled" src="https://github.com/user-attachments/assets/8de6d100-68c0-4bd3-9ce3-f5c06e1638c0" />

- **World** — displays the world you are on in the Discord rich presence state line (e.g. "At Falador (W302)", or just "World 302" when in an unrecognized region)

<img width="268" height="114" alt="DiscordWorldEnabled" src="https://github.com/user-attachments/assets/714be0dc-b755-4734-b671-6dbc64eb9056" />

Both options default to false to preserve existing behavior and respect player privacy.

<img width="271" height="117" alt="DiscordBothEnabled" src="https://github.com/user-attachments/assets/af9a6f55-e7f5-409b-b2ff-15c8cb6a5ed5" />

<img width="244" height="472" alt="ConfigPanel" src="https://github.com/user-attachments/assets/7a3649c9-bf7f-4e15-9305-c7c49f11c82f" />

`Client` is injected into `DiscordState` to read the player name and world number when building the presence update.
