### PR TITLE
cache: 238 world map support

### DIFF
--- a/cache/src/main/java/net/runelite/cache/WorldMapManager.java
+++ b/cache/src/main/java/net/runelite/cache/WorldMapManager.java
@@ -62,6 +62,7 @@ public class WorldMapManager
 		Index index = store.getIndex(IndexType.WORLDMAP);
 		Archive compositeMapArchive = index.findArchiveByName("compositemap");
 		WorldMapCompositeLoader worldMapCompositeLoader = new WorldMapCompositeLoader();
+		worldMapCompositeLoader.configureForRevision(index.getRevision());
 
 		ArchiveFiles compositeMapFiles = compositeMapArchive.getFiles(storage.loadArchive(compositeMapArchive));
 		for (FSFile compositeFile : compositeMapFiles.getFiles())

--- a/cache/src/main/java/net/runelite/cache/definitions/loaders/WorldMapCompositeLoader.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/loaders/WorldMapCompositeLoader.java
@@ -31,9 +31,17 @@ import net.runelite.cache.region.Position;
 
 public class WorldMapCompositeLoader
 {
+	private boolean rev238 = true;
+
+	public WorldMapCompositeLoader configureForRevision(int rev)
+	{
+		rev238 = rev > 425;
+		return this;
+	}
+
 	public WorldMapCompositeDefinition load(byte[] buffer)
 	{
-		WorldMapDataLoader worldMapDataLoader = new WorldMapDataLoader();
+		WorldMapDataLoader worldMapDataLoader = new WorldMapDataLoader(rev238);
 		WorldMapElementLoader worldMapElementLoader = new WorldMapElementLoader();
 
 		WorldMapCompositeDefinition worldMapCompositeDefinition = new WorldMapCompositeDefinition();

--- a/cache/src/main/java/net/runelite/cache/definitions/loaders/WorldMapDataLoader.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/loaders/WorldMapDataLoader.java
@@ -30,6 +30,18 @@ import net.runelite.cache.io.InputStream;
 
 public class WorldMapDataLoader
 {
+	private final boolean rev238;
+
+	public WorldMapDataLoader()
+	{
+		this(true);
+	}
+
+	public WorldMapDataLoader(boolean rev238)
+	{
+		this.rev238 = rev238;
+	}
+
 	public MapSquareDefinition loadMapSquare(InputStream in)
 	{
 		int worldMapDataType = in.readUnsignedByte();
@@ -46,8 +58,11 @@ public class WorldMapDataLoader
 		mapSquareDefinition.sourceSquareZ = in.readUnsignedShort();
 		mapSquareDefinition.displaySquareX = in.readUnsignedShort();
 		mapSquareDefinition.displaySquareZ = in.readUnsignedShort();
-		mapSquareDefinition.groupId = in.readBigSmart2();
-		mapSquareDefinition.fileId = in.readBigSmart2();
+		if (!rev238)
+		{
+			mapSquareDefinition.groupId = in.readBigSmart2();
+			mapSquareDefinition.fileId = in.readBigSmart2();
+		}
 
 		return mapSquareDefinition;
 	}
@@ -72,8 +87,11 @@ public class WorldMapDataLoader
 		zoneDefinition.displaySquareZ = in.readUnsignedShort();
 		zoneDefinition.displayZoneX = in.readUnsignedByte();
 		zoneDefinition.displayZoneZ = in.readUnsignedByte();
-		zoneDefinition.groupId = in.readBigSmart2();
-		zoneDefinition.fileId = in.readBigSmart2();
+		if (!rev238)
+		{
+			zoneDefinition.groupId = in.readBigSmart2();
+			zoneDefinition.fileId = in.readBigSmart2();
+		}
 
 		return zoneDefinition;
 	}


### PR DESCRIPTION
The client changed to using ids directly instead of looking up by name (`"details"` and `"compositemap"`), but they seem to still work. Might need another update in future if the cache stops storing the names.