### PR TITLE
AttackStyles: Add option to hide NPC attack options for warned attack styles.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesConfig.java
@@ -126,7 +126,10 @@ public interface AttackStylesConfig extends Config
 			description = "Hide NPC attack options when a warned attack style is selected.",
 			position = 9
 	)
-	default boolean hideNpcAttackOptions() { return false; }
+	default boolean hideNpcAttackOptions()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "showChatWarnings",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesConfig.java
@@ -121,10 +121,18 @@ public interface AttackStylesConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "hideNpcAttackOptions",
+			name = "Warned Hide NPC attack",
+			description = "Hide NPC attack options when a warned attack style is selected.",
+			position = 9
+	)
+	default boolean hideNpcAttackOptions() { return false; }
+
+	@ConfigItem(
 		keyName = "showChatWarnings",
 		name = "Show chat warnings",
 		description = "Show chat warnings about switching to an unwanted attack style.",
-		position = 9
+		position = 10
 	)
 	default boolean showChatWarnings()
 	{
@@ -135,7 +143,7 @@ public interface AttackStylesConfig extends Config
 		keyName = "warningNotification",
 		name = "Warning notification",
 		description = "Notification for switching to an unwanted attack style.",
-		position = 10
+		position = 11
 	)
 	default Notification warningNotification()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -63,6 +63,10 @@ import static net.runelite.client.plugins.attackstyles.AttackStyle.DEFENSIVE;
 import static net.runelite.client.plugins.attackstyles.AttackStyle.DEFENSIVE_CASTING;
 import static net.runelite.client.plugins.attackstyles.AttackStyle.OTHER;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.MenuAction;
+import java.util.Arrays;
+import net.runelite.api.events.PostMenuSort;
 
 @PluginDescriptor(
 	name = "Attack Styles",
@@ -260,6 +264,35 @@ public class AttackStylesPlugin extends Plugin
 			notifier.notify(config.warningNotification(), "Attack style changed to " + attackStyle.getName() + "!");
 		}
 		prevAttackStyle = attackStyle;
+	}
+
+	@Subscribe
+	public void onPostMenuSort(PostMenuSort event)
+	{
+		if (!config.hideNpcAttackOptions() || !warnedSkillSelected)
+		{
+			return;
+		}
+
+		MenuEntry[] filtered = Arrays.stream(client.getMenuEntries())
+				.filter(entry ->
+				{
+					if (!"Attack".equalsIgnoreCase(entry.getOption()))
+					{
+						return true;
+					}
+
+					MenuAction action = entry.getType();
+
+					return action != MenuAction.NPC_FIRST_OPTION
+							&& action != MenuAction.NPC_SECOND_OPTION
+							&& action != MenuAction.NPC_THIRD_OPTION
+							&& action != MenuAction.NPC_FOURTH_OPTION
+							&& action != MenuAction.NPC_FIFTH_OPTION;
+				})
+				.toArray(MenuEntry[]::new);
+
+		client.setMenuEntries(filtered);
 	}
 
 	private void resetWarnings()


### PR DESCRIPTION
Adding in option under the Attack Styles plugin to hide NPC attack options when a warned style is used.