### PR TITLE
adds ready check functionality to party plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyMemberBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyMemberBox.java
@@ -28,13 +28,15 @@ package net.runelite.client.plugins.party;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.util.Objects;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
-import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -54,6 +56,11 @@ class PartyMemberBox extends JPanel
 	private static final Color HP_BG = new Color(102, 15, 16, 230);
 	private static final Color PRAY_FG = new Color(0, 149, 151);
 	private static final Color PRAY_BG = Color.black;
+	private static final Color READY_COLOR = new Color(0, 200, 83);
+	private static final int AVATAR_SIZE = 32;
+	private static final int TICK_SIZE = 14;
+	private static final BufferedImage READY_TICK = ImageUtil.resizeImage(
+		ImageUtil.loadImageResource(PartyPlugin.class, "confirm_icon.png"), TICK_SIZE, TICK_SIZE);
 
 	@Getter(AccessLevel.PACKAGE)
 	private final PartyData memberPartyData;
@@ -67,7 +74,9 @@ class PartyMemberBox extends JPanel
 
 	private final PartyConfig config;
 
-	private boolean avatarSet;
+	private BufferedImage avatarBase;
+	private boolean avatarIconSet;
+	private Boolean renderedReady;
 
 	PartyMemberBox(final PartyConfig config, final JComponent panel, final PartyData memberPartyData,
 		final PartyService partyService)
@@ -85,9 +94,8 @@ class PartyMemberBox extends JPanel
 		container.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		container.setBorder(new EmptyBorder(5, 5, 5, 5));
 
-		// create a line border with the specified color and width
-		Border border = BorderFactory.createLineBorder(Color.gray, 1);
-		avatar.setBorder(border);
+		// border color reflects ready-check state; updated in update()
+		avatar.setBorder(BorderFactory.createLineBorder(Color.gray, 1));
 
 		avatar.setHorizontalAlignment(SwingConstants.CENTER);
 		avatar.setVerticalAlignment(SwingConstants.CENTER);
@@ -143,15 +151,28 @@ class PartyMemberBox extends JPanel
 	{
 		final PartyMember member = partyService.getMemberById(memberPartyData.getMemberId());
 
-		// Avatar
-		if (!avatarSet && member.getAvatar() != null)
+		final Boolean ready = memberPartyData.getReady();
+		final boolean isReady = Boolean.TRUE.equals(ready);
+
+		// Cache the resized avatar once it becomes available
+		if (avatarBase == null && member.getAvatar() != null)
 		{
-			ImageIcon icon = new ImageIcon(ImageUtil.resizeImage(member.getAvatar(), 32, 32));
+			avatarBase = ImageUtil.resizeImage(member.getAvatar(), AVATAR_SIZE, AVATAR_SIZE);
+		}
+
+		// (Re)build the avatar icon when it first becomes available or the ready state changes,
+		// overlaying a green tick on members that have answered ready
+		if (avatarBase != null && (!avatarIconSet || !Objects.equals(renderedReady, ready)))
+		{
+			ImageIcon icon = new ImageIcon(isReady ? withTick(avatarBase) : avatarBase);
 			icon.getImage().flush();
 			avatar.setIcon(icon);
-
-			avatarSet = true;
+			avatarIconSet = true;
+			renderedReady = ready;
 		}
+
+		// Outline ready members in green
+		avatar.setBorder(BorderFactory.createLineBorder(isReady ? READY_COLOR : Color.gray, 1));
 
 		// Update progress bars
 		hpBar.setValue(memberPartyData.getHitpoints());
@@ -173,5 +194,16 @@ class PartyMemberBox extends JPanel
 	private static String progressBarLabel(int current, int max)
 	{
 		return current + "/" + max;
+	}
+
+	private static BufferedImage withTick(BufferedImage base)
+	{
+		BufferedImage out = new BufferedImage(base.getWidth(), base.getHeight(), BufferedImage.TYPE_INT_ARGB);
+		Graphics g = out.getGraphics();
+		g.drawImage(base, 0, 0, null);
+		// bottom-right corner
+		g.drawImage(READY_TICK, base.getWidth() - READY_TICK.getWidth(), base.getHeight() - READY_TICK.getHeight(), null);
+		g.dispose();
+		return out;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
@@ -28,6 +28,7 @@ import com.google.inject.Inject;
 import java.awt.BorderLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.GridLayout;
 import java.awt.Insets;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -36,6 +37,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JOptionPane;
@@ -48,6 +50,7 @@ import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.DragAndDropReorderPane;
 import net.runelite.client.ui.components.PluginErrorPanel;
+import net.runelite.client.util.ImageUtil;
 
 class PartyPanel extends PluginPanel
 {
@@ -64,6 +67,12 @@ class PartyPanel extends PluginPanel
 	private final JButton joinPartyButton = new JButton();
 	private final JButton rejoinPartyButton = new JButton();
 	private final JButton copyPartyIdButton = new JButton();
+	private final JButton readyCheckButton = new JButton();
+	private final JButton readyButton = new JButton();
+	private final JButton notReadyButton = new JButton();
+
+	private final JPanel startReadyCheckPanel = new JPanel(new BorderLayout());
+	private final JPanel respondReadyCheckPanel = new JPanel(new GridLayout(1, 2, 4, 0));
 
 	private final PluginErrorPanel noPartyPanel = new PluginErrorPanel();
 	private final PluginErrorPanel partyEmptyPanel = new PluginErrorPanel();
@@ -111,7 +120,26 @@ class PartyPanel extends PluginPanel
 		c.gridwidth = 2;
 		topPanel.add(rejoinPartyButton, c);
 
+		readyCheckButton.setText("Ready check");
+		readyCheckButton.setFocusable(false);
+		startReadyCheckPanel.setBorder(new EmptyBorder(0, 0, 4, 0));
+		startReadyCheckPanel.add(readyCheckButton, BorderLayout.CENTER);
+
+		readyButton.setText("Ready");
+		readyButton.setFocusable(false);
+		readyButton.setIcon(new ImageIcon(ImageUtil.loadImageResource(PartyPlugin.class, "confirm_icon.png")));
+
+		notReadyButton.setText("Not ready");
+		notReadyButton.setFocusable(false);
+		notReadyButton.setIcon(new ImageIcon(ImageUtil.loadImageResource(PartyPlugin.class, "cancel_icon.png")));
+
+		respondReadyCheckPanel.setBorder(new EmptyBorder(0, 0, 4, 0));
+		respondReadyCheckPanel.add(readyButton);
+		respondReadyCheckPanel.add(notReadyButton);
+
 		layoutPanel.add(topPanel);
+		layoutPanel.add(startReadyCheckPanel);
+		layoutPanel.add(respondReadyCheckPanel);
 		layoutPanel.add(memberBoxPanel);
 
 		startButton.setText(party.isInParty() ? BTN_LEAVE_TEXT : BTN_CREATE_TEXT);
@@ -202,6 +230,10 @@ class PartyPanel extends PluginPanel
 			}
 		});
 
+		readyCheckButton.addActionListener(e -> plugin.startReadyCheck());
+		readyButton.addActionListener(e -> plugin.respondReadyCheck(true));
+		notReadyButton.addActionListener(e -> plugin.respondReadyCheck(false));
+
 		noPartyPanel.setContent("Not in a party", "Create a party to begin.");
 
 		updateParty();
@@ -227,6 +259,17 @@ class PartyPanel extends PluginPanel
 					"Your party passphrase is: " + party.getPartyPassphrase() + ".");
 			add(partyEmptyPanel);
 		}
+
+		updateReadyCheck();
+	}
+
+	void updateReadyCheck()
+	{
+		final boolean inParty = party.isInParty();
+		final boolean active = plugin.isReadyCheckActive();
+
+		startReadyCheckPanel.setVisible(inParty && !active);
+		respondReadyCheckPanel.setVisible(inParty && active);
 	}
 
 	void addMember(PartyData partyData)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -80,6 +80,8 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.party.data.PartyData;
 import net.runelite.client.plugins.party.data.PartyTilePingData;
 import net.runelite.client.plugins.party.messages.LocationUpdate;
+import net.runelite.client.plugins.party.messages.ReadyCheckRequest;
+import net.runelite.client.plugins.party.messages.ReadyCheckResponse;
 import net.runelite.client.plugins.party.messages.StatusUpdate;
 import net.runelite.client.plugins.party.messages.TilePing;
 import net.runelite.client.task.Schedule;
@@ -156,6 +158,9 @@ public class PartyPlugin extends Plugin
 	private WorldPoint lastLocation;
 	private StatusUpdate lastStatus;
 
+	@Getter
+	private boolean readyCheckActive;
+
 	private final HotkeyListener hotkeyListener = new HotkeyListener(() -> config.pingHotkey())
 	{
 		@Override
@@ -202,6 +207,8 @@ public class PartyPlugin extends Plugin
 		wsClient.registerMessage(TilePing.class);
 		wsClient.registerMessage(LocationUpdate.class);
 		wsClient.registerMessage(StatusUpdate.class);
+		wsClient.registerMessage(ReadyCheckRequest.class);
+		wsClient.registerMessage(ReadyCheckResponse.class);
 		// Delay sync so the eventbus can register prior to the sync response
 		SwingUtilities.invokeLater(this::requestSync);
 	}
@@ -223,8 +230,11 @@ public class PartyPlugin extends Plugin
 		wsClient.unregisterMessage(TilePing.class);
 		wsClient.unregisterMessage(LocationUpdate.class);
 		wsClient.unregisterMessage(StatusUpdate.class);
+		wsClient.unregisterMessage(ReadyCheckRequest.class);
+		wsClient.unregisterMessage(ReadyCheckResponse.class);
 		lastLocation = null;
 		lastStatus = null;
+		readyCheckActive = false;
 	}
 
 	@Provides
@@ -245,6 +255,22 @@ public class PartyPlugin extends Plugin
 	void leaveParty()
 	{
 		party.changeParty(null);
+	}
+
+	void startReadyCheck()
+	{
+		if (party.isInParty())
+		{
+			party.send(new ReadyCheckRequest());
+		}
+	}
+
+	void respondReadyCheck(boolean ready)
+	{
+		if (party.isInParty() && readyCheckActive)
+		{
+			party.send(new ReadyCheckResponse(ready));
+		}
 	}
 
 	@Subscribe
@@ -453,6 +479,110 @@ public class PartyPlugin extends Plugin
 	}
 
 	@Subscribe
+	public void onReadyCheckRequest(final ReadyCheckRequest event)
+	{
+		final PartyMember member = party.getMemberById(event.getMemberId());
+		if (member == null)
+		{
+			return;
+		}
+
+		// Begin a fresh check, clearing any responses from a previous one
+		clearReadyStates();
+		readyCheckActive = true;
+
+		queueChatMessage(member.getDisplayName() + " has started a ready check. Respond in the Party panel.");
+
+		SwingUtilities.invokeLater(() ->
+		{
+			panel.updateReadyCheck();
+			panel.updateAll();
+		});
+	}
+
+	@Subscribe
+	public void onReadyCheckResponse(final ReadyCheckResponse event)
+	{
+		if (!readyCheckActive)
+		{
+			return;
+		}
+
+		final PartyData partyData = getPartyData(event.getMemberId());
+		if (partyData == null)
+		{
+			return;
+		}
+
+		partyData.setReady(event.isReady());
+		SwingUtilities.invokeLater(() -> panel.updateMember(event.getMemberId()));
+
+		final PartyMember member = party.getMemberById(event.getMemberId());
+		final String name = member != null ? member.getDisplayName() : "A party member";
+
+		if (!event.isReady())
+		{
+			queueChatMessage("Ready check failed: " + name + " is not ready.");
+			endReadyCheck();
+		}
+		else if (allMembersReady())
+		{
+			queueChatMessage("Ready check passed: all party members are ready!");
+			endReadyCheck();
+		}
+	}
+
+	private boolean allMembersReady()
+	{
+		final List<PartyMember> members = party.getMembers();
+		if (members.isEmpty())
+		{
+			return false;
+		}
+
+		for (PartyMember member : members)
+		{
+			final PartyData partyData = partyDataMap.get(member.getMemberId());
+			if (partyData == null || !Boolean.TRUE.equals(partyData.getReady()))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private void endReadyCheck()
+	{
+		readyCheckActive = false;
+		clearReadyStates();
+		SwingUtilities.invokeLater(() ->
+		{
+			panel.updateReadyCheck();
+			panel.updateAll();
+		});
+	}
+
+	private void clearReadyStates()
+	{
+		synchronized (partyDataMap)
+		{
+			for (PartyData partyData : partyDataMap.values())
+			{
+				partyData.setReady(null);
+			}
+		}
+	}
+
+	private void queueChatMessage(String message)
+	{
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.GAMEMESSAGE)
+			.value(message)
+			.build());
+	}
+
+	@Subscribe
 	public void onLocationUpdate(final LocationUpdate event)
 	{
 		final PartyData partyData = getPartyData(event.getMemberId());
@@ -587,12 +717,20 @@ public class PartyPlugin extends Plugin
 
 			SwingUtilities.invokeLater(() -> panel.removeMember(event.getMemberId()));
 		}
+
+		// A member leaving may have been the only one not yet ready
+		if (readyCheckActive && allMembersReady())
+		{
+			queueChatMessage("Ready check passed: all party members are ready!");
+			endReadyCheck();
+		}
 	}
 
 	@Subscribe
 	public void onPartyChanged(final PartyChanged event)
 	{
 		// Reset party
+		readyCheckActive = false;
 		partyDataMap.clear();
 		pendingTilePings.clear();
 		worldMapManager.removeIf(PartyWorldMapPoint.class::isInstance);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -80,6 +80,8 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.party.data.PartyData;
 import net.runelite.client.plugins.party.data.PartyTilePingData;
 import net.runelite.client.plugins.party.messages.LocationUpdate;
+import net.runelite.client.plugins.party.messages.ReadyCheckRequest;
+import net.runelite.client.plugins.party.messages.ReadyCheckResponse;
 import net.runelite.client.plugins.party.messages.StatusUpdate;
 import net.runelite.client.plugins.party.messages.TilePing;
 import net.runelite.client.task.Schedule;
@@ -156,6 +158,9 @@ public class PartyPlugin extends Plugin
 	private WorldPoint lastLocation;
 	private StatusUpdate lastStatus;
 
+	@Getter
+	private boolean readyCheckActive;
+
 	private final HotkeyListener hotkeyListener = new HotkeyListener(() -> config.pingHotkey())
 	{
 		@Override
@@ -202,6 +207,8 @@ public class PartyPlugin extends Plugin
 		wsClient.registerMessage(TilePing.class);
 		wsClient.registerMessage(LocationUpdate.class);
 		wsClient.registerMessage(StatusUpdate.class);
+		wsClient.registerMessage(ReadyCheckRequest.class);
+		wsClient.registerMessage(ReadyCheckResponse.class);
 		// Delay sync so the eventbus can register prior to the sync response
 		SwingUtilities.invokeLater(this::requestSync);
 	}
@@ -223,8 +230,11 @@ public class PartyPlugin extends Plugin
 		wsClient.unregisterMessage(TilePing.class);
 		wsClient.unregisterMessage(LocationUpdate.class);
 		wsClient.unregisterMessage(StatusUpdate.class);
+		wsClient.unregisterMessage(ReadyCheckRequest.class);
+		wsClient.unregisterMessage(ReadyCheckResponse.class);
 		lastLocation = null;
 		lastStatus = null;
+		readyCheckActive = false;
 	}
 
 	@Provides
@@ -245,6 +255,22 @@ public class PartyPlugin extends Plugin
 	void leaveParty()
 	{
 		party.changeParty(null);
+	}
+
+	void startReadyCheck()
+	{
+		if (party.isInParty())
+		{
+			party.send(new ReadyCheckRequest());
+		}
+	}
+
+	void respondReadyCheck(boolean ready)
+	{
+		if (party.isInParty() && readyCheckActive)
+		{
+			party.send(new ReadyCheckResponse(ready));
+		}
 	}
 
 	@Subscribe
@@ -453,6 +479,110 @@ public class PartyPlugin extends Plugin
 	}
 
 	@Subscribe
+	public void onReadyCheckRequest(final ReadyCheckRequest event)
+	{
+		final PartyMember member = party.getMemberById(event.getMemberId());
+		if (member == null)
+		{
+			return;
+		}
+
+		// Begin a fresh check, clearing any responses from a previous one
+		clearReadyStates();
+		readyCheckActive = true;
+
+		queueChatMessage(member.getDisplayName() + " has started a ready check. Respond in the Party panel.");
+
+		SwingUtilities.invokeLater(() ->
+		{
+			panel.updateReadyCheck();
+			panel.updateAll();
+		});
+	}
+
+	@Subscribe
+	public void onReadyCheckResponse(final ReadyCheckResponse event)
+	{
+		if (!readyCheckActive)
+		{
+			return;
+		}
+
+		final PartyData partyData = getPartyData(event.getMemberId());
+		if (partyData == null)
+		{
+			return;
+		}
+
+		partyData.setReady(event.isReady());
+		SwingUtilities.invokeLater(() -> panel.updateMember(event.getMemberId()));
+
+		final PartyMember member = party.getMemberById(event.getMemberId());
+		final String name = member != null ? member.getDisplayName() : "A party member";
+
+		if (!event.isReady())
+		{
+			queueChatMessage("Ready check failed: " + name + " is not ready.");
+			endReadyCheck();
+		}
+		else if (allMembersReady())
+		{
+			queueChatMessage("Ready check passed: all party members are ready!");
+			endReadyCheck();
+		}
+	}
+
+	private boolean allMembersReady()
+	{
+		final List<PartyMember> members = party.getMembers();
+		if (members.isEmpty())
+		{
+			return false;
+		}
+
+		for (PartyMember member : members)
+		{
+			final PartyData partyData = partyDataMap.get(member.getMemberId());
+			if (partyData == null || !Boolean.TRUE.equals(partyData.getReady()))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private void endReadyCheck()
+	{
+		readyCheckActive = false;
+		clearReadyStates();
+		SwingUtilities.invokeLater(() ->
+		{
+			panel.updateReadyCheck();
+			panel.updateAll();
+		});
+	}
+
+	private void clearReadyStates()
+	{
+		synchronized (partyDataMap)
+		{
+			for (PartyData partyData : partyDataMap.values())
+			{
+				partyData.setReady(null);
+			}
+		}
+	}
+
+	private void queueChatMessage(String message)
+	{
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.DIDYOUKNOW)
+			.value(message)
+			.build());
+	}
+
+	@Subscribe
 	public void onLocationUpdate(final LocationUpdate event)
 	{
 		final PartyData partyData = getPartyData(event.getMemberId());
@@ -587,12 +717,20 @@ public class PartyPlugin extends Plugin
 
 			SwingUtilities.invokeLater(() -> panel.removeMember(event.getMemberId()));
 		}
+
+		// A member leaving may have been the only one not yet ready
+		if (readyCheckActive && allMembersReady())
+		{
+			queueChatMessage("Ready check passed: all party members are ready!");
+			endReadyCheck();
+		}
 	}
 
 	@Subscribe
 	public void onPartyChanged(final PartyChanged event)
 	{
 		// Reset party
+		readyCheckActive = false;
 		partyDataMap.clear();
 		pendingTilePings.clear();
 		worldMapManager.removeIf(PartyWorldMapPoint.class::isInstance);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/messages/ReadyCheckRequest.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/messages/ReadyCheckRequest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2019, Tomas Slusny <slusnucky@gmail.com>
- * Copyright (c) 2021, Jonathan Rousseau <https://github.com/JoRouss>
+ * Copyright (c) 2026, George Green <green.gw@pm.me>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,33 +22,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.party.data;
+package net.runelite.client.plugins.party.messages;
 
-import java.awt.Color;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import net.runelite.client.ui.overlay.components.PanelComponent;
-import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
+import net.runelite.client.party.messages.PartyMemberMessage;
 
-@Setter
-@Getter
-@RequiredArgsConstructor
-public class PartyData
+/**
+ * Sent by a party member to start a ready check. Every member is expected to
+ * answer with a {@link ReadyCheckResponse}.
+ */
+public class ReadyCheckRequest extends PartyMemberMessage
 {
-	private final long memberId;
-	private final WorldMapPoint worldMapPoint;
-	private final PanelComponent panel = new PanelComponent();
-	private Color color = Color.WHITE;
-
-	private int hitpoints;
-	private int maxHitpoints;
-	private int prayer;
-	private int maxPrayer;
-	private int runEnergy;
-	private int specEnergy;
-	private boolean vengeanceActive;
-
-	// Ready check state: null = no response in the current check, TRUE = ready, FALSE = not ready
-	private Boolean ready;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/messages/ReadyCheckRequest.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/messages/ReadyCheckRequest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2019, Tomas Slusny <slusnucky@gmail.com>
- * Copyright (c) 2021, Jonathan Rousseau <https://github.com/JoRouss>
+ * Copyright (c) 2026, George Green <green.george.95@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,33 +22,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.party.data;
+package net.runelite.client.plugins.party.messages;
 
-import java.awt.Color;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import net.runelite.client.ui.overlay.components.PanelComponent;
-import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
+import net.runelite.client.party.messages.PartyMemberMessage;
 
-@Setter
-@Getter
-@RequiredArgsConstructor
-public class PartyData
+/**
+ * Sent by a party member to start a ready check. Every member is expected to
+ * answer with a {@link ReadyCheckResponse}.
+ */
+public class ReadyCheckRequest extends PartyMemberMessage
 {
-	private final long memberId;
-	private final WorldMapPoint worldMapPoint;
-	private final PanelComponent panel = new PanelComponent();
-	private Color color = Color.WHITE;
-
-	private int hitpoints;
-	private int maxHitpoints;
-	private int prayer;
-	private int maxPrayer;
-	private int runEnergy;
-	private int specEnergy;
-	private boolean vengeanceActive;
-
-	// Ready check state: null = no response in the current check, TRUE = ready, FALSE = not ready
-	private Boolean ready;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/messages/ReadyCheckResponse.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/messages/ReadyCheckResponse.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2019, Tomas Slusny <slusnucky@gmail.com>
- * Copyright (c) 2021, Jonathan Rousseau <https://github.com/JoRouss>
+ * Copyright (c) 2026, George Green <green.george.95@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,33 +22,24 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.party.data;
+package net.runelite.client.plugins.party.messages;
 
-import java.awt.Color;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import net.runelite.client.ui.overlay.components.PanelComponent;
-import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import net.runelite.client.party.messages.PartyMemberMessage;
 
-@Setter
-@Getter
-@RequiredArgsConstructor
-public class PartyData
+/**
+ * A party member's answer to an active ready check.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class ReadyCheckResponse extends PartyMemberMessage
 {
-	private final long memberId;
-	private final WorldMapPoint worldMapPoint;
-	private final PanelComponent panel = new PanelComponent();
-	private Color color = Color.WHITE;
-
-	private int hitpoints;
-	private int maxHitpoints;
-	private int prayer;
-	private int maxPrayer;
-	private int runEnergy;
-	private int specEnergy;
-	private boolean vengeanceActive;
-
-	// Ready check state: null = no response in the current check, TRUE = ready, FALSE = not ready
-	private Boolean ready;
+	@SerializedName("r")
+	private boolean ready;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/messages/ReadyCheckResponse.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/messages/ReadyCheckResponse.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2019, Tomas Slusny <slusnucky@gmail.com>
- * Copyright (c) 2021, Jonathan Rousseau <https://github.com/JoRouss>
+ * Copyright (c) 2026, George Green <green.gw@pm.me>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,33 +22,24 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.party.data;
+package net.runelite.client.plugins.party.messages;
 
-import java.awt.Color;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import net.runelite.client.ui.overlay.components.PanelComponent;
-import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import net.runelite.client.party.messages.PartyMemberMessage;
 
-@Setter
-@Getter
-@RequiredArgsConstructor
-public class PartyData
+/**
+ * A party member's answer to an active ready check.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class ReadyCheckResponse extends PartyMemberMessage
 {
-	private final long memberId;
-	private final WorldMapPoint worldMapPoint;
-	private final PanelComponent panel = new PanelComponent();
-	private Color color = Color.WHITE;
-
-	private int hitpoints;
-	private int maxHitpoints;
-	private int prayer;
-	private int maxPrayer;
-	private int runEnergy;
-	private int specEnergy;
-	private boolean vengeanceActive;
-
-	// Ready check state: null = no response in the current check, TRUE = ready, FALSE = not ready
-	private Boolean ready;
+	@SerializedName("r")
+	private boolean ready;
 }


### PR DESCRIPTION
Any party member can initiate a ready check.

When all members respond ready or any member responds not ready the check ends with an appropriate message.