### PR TITLE
Update PluginHub disclaimer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -516,7 +516,7 @@ class PluginHubPanel extends PluginPanel
 		});
 
 		JLabel externalPluginWarning1 = new JLabel("<html>External plugins are reviewed to help " +
-			"ensure they are not malicious, or rule- " +
+			"ensure they are not malicious or rule- " +
 			"breaking, but this is not guaranteed. " +
 			"They may cause bugs or instability.</html>");
 		externalPluginWarning1.setBackground(new Color(0xFFBB33));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -515,9 +515,9 @@ class PluginHubPanel extends PluginPanel
 			}
 		});
 
-		JLabel externalPluginWarning1 = new JLabel("<html>External plugins are verified to not be " +
-			"malicious or rule-breaking, but are not " +
-			"maintained by the RuneLite developers. " +
+		JLabel externalPluginWarning1 = new JLabel("<html>External plugins are reviewed to help " +
+			"ensure they are not malicious, or rule- " +
+			"breaking, but this is not guaranteed. " +
 			"They may cause bugs or instability.</html>");
 		externalPluginWarning1.setBackground(new Color(0xFFBB33));
 		externalPluginWarning1.setForeground(Color.BLACK);


### PR DESCRIPTION
# What changed
Changing the disclaimer to include that it is not guaranteed that plugins are not rule-breaking. I had to remove "are not maintained by the RuneLite developers" to keep it on 4 lines, the idea here is that the word "External" already tells you that they are not maintained by RL devs but maybe there is a better way of wording it, open to suggestions.

<img width="277" height="196" alt="image" src="https://github.com/user-attachments/assets/3203fdbf-94b8-4355-aff3-2f980b88935d" />


# Why
Especially relevant now with the Marni + click to minimize drama, but this has happened before as well. The current disclaimer reads as a guarantee that you will not be banned for using RuneLite plugins, but this is not a promise RuneLite can make because:

- Jagex's plugin rules are vague and can change at any point in time.
- RuneLite developers are overrun by PRs and need to use AI for reviews, which we can not promise are always accurate.
- Even without AI, humans can miss things and/or misinterpret Jagex's guidelines.
- There have been multiple instances where this promise has not held true in the past.

As it stands right now, many community members put most of the blame on RuneLite maintainers, and I think this disclaimer is a big part of it.

Quote [from Discord](https://discord.com/channels/301497432909414422/301497432909414422/1516793202789584927):

> Especially with the rate of new plugins and plugin updates, RL can't possibly be expected to foresee every weird use-case of every niche plugin that allows a player to play the game in ways clearly not intended.
> 
> What's concerning is when you have players excusing gameplay behaviour that's not in keeping with RS's values by pointing at a statement like this and saying "well RL said it's ok," rather than applying their own common sense and reasonable interpretations of official rules.
> 
> If RL was owned/ran by Jagex, if Jagex directly vetted each plugin, it'd be reasonable to leave as-is. But a program ran by volunteer reviewers probably shouldn't be carrying the weight of what this statement implies

Adam seemed OK with the idea [on Discord](https://discord.com/channels/301497432909414422/301497432909414422/1516798315696754728):
<img width="796" height="78" alt="image" src="https://github.com/user-attachments/assets/7421bfa3-94bf-455f-be54-56c97a0bd760" />
