### PR TITLE
cache: use id for compositemap and details when necessary

### DIFF
--- a/cache/src/main/java/net/runelite/cache/WorldMapManager.java
+++ b/cache/src/main/java/net/runelite/cache/WorldMapManager.java
@@ -46,6 +46,9 @@ import java.util.Map;
 
 public class WorldMapManager
 {
+	public static final int DETAILS_ID = 0;
+	public static final int COMPOSITEMAP_ID = 1;
+
 	private final Store store;
 	private final List<WorldMapCompositeDefinition> worldMapCompositeDefinitions = new ArrayList<>();
 	private final List<WorldMapElementDefinition> elements = new ArrayList<>();
@@ -60,7 +63,7 @@ public class WorldMapManager
 	{
 		Storage storage = store.getStorage();
 		Index index = store.getIndex(IndexType.WORLDMAP);
-		Archive compositeMapArchive = index.findArchiveByName("compositemap");
+		Archive compositeMapArchive = index.isNamed() ? index.findArchiveByName("compositemap") : index.getArchive(COMPOSITEMAP_ID);
 		WorldMapCompositeLoader worldMapCompositeLoader = new WorldMapCompositeLoader();
 		worldMapCompositeLoader.configureForRevision(index.getRevision());
 

--- a/cache/src/test/java/net/runelite/cache/WorldMapDumperTest.java
+++ b/cache/src/test/java/net/runelite/cache/WorldMapDumperTest.java
@@ -69,7 +69,7 @@ public class WorldMapDumperTest
 
 			Storage storage = store.getStorage();
 			Index index = store.getIndex(IndexType.WORLDMAP);
-			Archive archive = index.findArchiveByName("details");
+			Archive archive = index.isNamed() ? index.findArchiveByName("details") : index.getArchive(WorldMapManager.DETAILS_ID);
 
 			byte[] archiveData = storage.loadArchive(archive);
 			ArchiveFiles files = archive.getFiles(archiveData);


### PR DESCRIPTION
Follow up to #20191 since they apparently stopped having names after the first 238 cache.