### PR TITLE
config: show world type in the rsprofile default tooltip

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
@@ -468,6 +468,11 @@ class ProfilePanel extends PluginPanel
 					if (defaultForRsProfiles == null || defaultForRsProfiles.isEmpty())
 					{
 						tooltip.append("Set profile as default for the current RuneScape account");
+						final RuneScapeProfileType currentType = configManager.getConfiguration(ConfigManager.RSPROFILE_GROUP, configManager.getRSProfileKey(), ConfigManager.RSPROFILE_TYPE, RuneScapeProfileType.class);
+						if (currentType != null && currentType != RuneScapeProfileType.STANDARD)
+						{
+							tooltip.append(" on ").append(Text.titleCase(currentType)).append(" worlds");
+						}
 					}
 					else
 					{


### PR DESCRIPTION
### Problem

The "set as default" link button on a profile card binds the profile to the current RuneScape account **and world type** — an account can have a different default profile per `RuneScapeProfileType` (Standard / League / Deadman). The "default for" tooltip already reflects this by labelling non-standard types, e.g. `Spryt (Raging Echoes League)`.

However, the tooltip shown *before* you set it just says:

> Set profile as default for the current RuneScape account

This gives no hint that the binding is world-type specific. There's no way to know — without reading the code — that clicking the link while logged into a Leagues/Deadman world binds the profile to *that world type* rather than the account globally. It makes the (otherwise nice) per-world-type profile feature effectively undiscoverable.

### Change

When the current RuneScape profile's world type is non-standard, append it to the set tooltip, mirroring how the existing "default for" branch already labels types:

- Standard worlds (unchanged): `Set profile as default for the current RuneScape account`
- League/Deadman worlds: `Set profile as default for the current RuneScape account on Raging Echoes League worlds`

The world type is read the same way as the adjacent code (the current `getRSProfileKey()` + `RSPROFILE_TYPE`), so no new dependencies and no behavioural change — only the tooltip text.