### PR TITLE
keyremapping: add shift 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
@@ -298,4 +298,15 @@ public interface KeyRemappingConfig extends Config
 	{
 		return new ModifierlessKeybind(KeyEvent.VK_UNDEFINED, InputEvent.CTRL_DOWN_MASK);
 	}
+
+	@ConfigItem(
+			position = 22,
+			keyName = "shift",
+			name = "Shift",
+			description = "The key which will replace shift."
+	)
+	default ModifierlessKeybind shift()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_UNDEFINED, InputEvent.SHIFT_DOWN_MASK);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -167,6 +167,11 @@ class KeyRemappingListener implements KeyListener
 				mappedKeyCode = KeyEvent.VK_CONTROL;
 			}
 
+			if (!plugin.isOptionsDialogOpen() && config.shift().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_SHIFT;
+			}
+
 			if (mappedKeyCode != KeyEvent.VK_UNDEFINED && mappedKeyCode != e.getKeyCode())
 			{
 				final char keyChar = e.getKeyChar();

--- a/runelite-client/src/test/java/net/runelite/client/plugins/keyremapping/KeyRemappingListenerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/keyremapping/KeyRemappingListenerTest.java
@@ -65,6 +65,7 @@ public class KeyRemappingListenerTest
 	{
 		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
 		when(keyRemappingConfig.control()).thenReturn(new ModifierlessKeybind(KeyEvent.VK_UNDEFINED, InputEvent.CTRL_DOWN_MASK));
+		when(keyRemappingConfig.shift()).thenReturn(new ModifierlessKeybind(KeyEvent.VK_SHIFT, InputEvent.SHIFT_DOWN_MASK));
 	}
 
 	@Test
@@ -138,5 +139,19 @@ public class KeyRemappingListenerTest
 		keyRemappingListener.keyPressed(event);
 
 		verify(event).setKeyCode(KeyEvent.VK_CONTROL);
+	}
+
+	@Test
+	public void testShiftRemap()
+	{
+		when(keyRemappingConfig.shift()).thenReturn(new ModifierlessKeybind(KeyEvent.VK_NUMPAD1, 0));
+		when(keyRemappingPlugin.chatboxFocused()).thenReturn(true);
+
+		KeyEvent event = mock(KeyEvent.class);
+		when(event.getExtendedKeyCode()).thenReturn(KeyEvent.VK_NUMPAD1); // for keybind matches()
+
+		keyRemappingListener.keyPressed(event);
+
+		verify(event).setKeyCode(KeyEvent.VK_SHIFT);
 	}
 }


### PR DESCRIPTION
Small change to add Shift to Key Remapping plugin. I have tested with every interface I can think of in game.

There is a plugin that exists to solve this problem: https://runelite.net/plugin-hub/show/shift-remapping
This plugin however has its own "Press Enter to Chat" logic that conflicts with Key Remapping when both plugins are enabled, and it seems unnecessary to have a whole plugin for this feature anyway.

There is an old PR #16338 for this same functionality but was untested, unlike this one.
