### PR TITLE
banktags: add layout reordering settings

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
@@ -76,6 +76,17 @@ public interface BankTagsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "layoutReorderMode",
+		name = "Layout reorder mode",
+		description = "How items are reordered when dragging in a tag tab layout.",
+		position = 5
+	)
+	default LayoutReorderMode layoutReorderMode()
+	{
+		return LayoutReorderMode.RESPECT_GAME;
+	}
+
+	@ConfigItem(
 		keyName = "position",
 		name = "",
 		description = "",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/LayoutReorderMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/LayoutReorderMode.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026, umer-rs <https://github.com/umer-rs>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.banktags;
+
+public enum LayoutReorderMode
+{
+	RESPECT_GAME,
+	SWAP,
+	INSERT
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java
@@ -74,7 +74,9 @@ import net.runelite.client.game.chatbox.ChatboxPanelManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.bank.BankSearch;
 import net.runelite.client.plugins.banktags.BankTag;
+import net.runelite.client.plugins.banktags.BankTagsConfig;
 import net.runelite.client.plugins.banktags.BankTagsPlugin;
+import net.runelite.client.plugins.banktags.LayoutReorderMode;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.BANK_ITEMS_PER_ROW;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.BANK_ITEM_HEIGHT;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.BANK_ITEM_START_X;
@@ -101,13 +103,14 @@ public class LayoutManager
 	private final PotionStorage potionStorage;
 	private final EventBus eventBus;
 	private final ConfigManager configManager;
+	private final BankTagsConfig config;
 
 	private final List<PluginAutoLayout> autoLayouts = new ArrayList<>();
 
 	@Inject
 	LayoutManager(Client client, ItemManager itemManager, BankTagsPlugin plugin, ChatboxPanelManager chatboxPanelManager,
 		BankSearch bankSearch, ChatMessageManager chatMessageManager,
-		PotionStorage potionStorage, EventBus eventBus, ConfigManager configManager)
+		PotionStorage potionStorage, EventBus eventBus, ConfigManager configManager, BankTagsConfig config)
 	{
 		this.client = client;
 		this.itemManager = itemManager;
@@ -118,6 +121,7 @@ public class LayoutManager
 		this.potionStorage = potionStorage;
 		this.eventBus = eventBus;
 		this.configManager = configManager;
+		this.config = config;
 
 		registerAutoLayout(plugin, "Default", new DefaultLayout());
 	}
@@ -469,7 +473,20 @@ public class LayoutManager
 		int sidx = source.getIndex();
 		int tidx = target.getIndex();
 
-		boolean swap = client.getVarbitValue(VarbitID.BANK_INSERTMODE) == 0;
+		boolean swap;
+		LayoutReorderMode reorderMode = config.layoutReorderMode();
+		if (reorderMode == LayoutReorderMode.SWAP)
+		{
+			swap = true;
+		}
+		else if (reorderMode == LayoutReorderMode.INSERT)
+		{
+			swap = false;
+		}
+		else
+		{
+			swap = client.getVarbitValue(VarbitID.BANK_INSERTMODE) == 0;
+		}
 
 		if (sidx >= l.size() || tidx >= l.size())
 		{


### PR DESCRIPTION
Add layout reordering settings to modify how dragging within a bank tag layout works. Default to "Respect Game".

<img width="242" height="353" alt="image" src="https://github.com/user-attachments/assets/df6b9f37-63c4-4af6-a7ef-ad8f52ae85a3" />

https://github.com/runelite/runelite/issues/18666