### PR TITLE
time tracking: fix special patch showing ready due to empty compost bins

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTracker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTracker.java
@@ -460,7 +460,10 @@ public class FarmingTracker
 
 				allUnknown = false;
 
-				if (prediction.getProduce() != Produce.WEEDS && prediction.getProduce() != Produce.SCARECROW)
+				if (prediction.getProduce() != Produce.WEEDS
+					&& prediction.getProduce() != Produce.SCARECROW
+					&& prediction.getCropState() != CropState.EMPTY
+					&& prediction.getCropState() != CropState.FILLING)
 				{
 					allEmpty = false;
 


### PR DESCRIPTION
Fix empty/filling compost bins causing special patches to show as "ready" on overview page. The solution proposed [here](https://github.com/runelite/runelite/issues/13006#issuecomment-2963194469) worked for empty bins but not for filling ones, as the produce in that case is a type of compost rather than a bin. Fixes #13006 

## Before
<img width="241" height="813" alt="image" src="https://github.com/user-attachments/assets/3706fef9-7502-4fd5-b735-591941537de6" />
<img width="233" height="1060" alt="image" src="https://github.com/user-attachments/assets/e4782d46-375f-4614-9491-5a2e87b6db34" />

## After
<img width="239" height="843" alt="image" src="https://github.com/user-attachments/assets/f54dace3-db4d-4ee4-8ff6-5a614f3c33c9" />
<img width="229" height="1052" alt="image" src="https://github.com/user-attachments/assets/64e5d26e-3a4d-4a66-a6ca-3f22963311b3" />
<img width="233" height="1057" alt="image" src="https://github.com/user-attachments/assets/f5aae4c9-2c74-4431-ab54-11fc7ecbe10e" />