### PR TITLE
audio: support raw PCM playback with a stoppable handle

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/audio/AudioPlayer.java
+++ b/runelite-client/src/main/java/net/runelite/client/audio/AudioPlayer.java
@@ -29,7 +29,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import javax.annotation.Nullable;
 import javax.inject.Singleton;
+import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.Clip;
@@ -141,6 +143,78 @@ public class AudioPlayer
 		});
 
 		return clip;
+	}
+
+	/**
+	 * A handle to in-progress playback, allowing it to be stopped before it finishes on its own.
+	 */
+	public interface Playback
+	{
+		/**
+		 * Stops playback and releases the underlying line. A no-op once playback has already ended.
+		 */
+		void stop();
+	}
+
+	/**
+	 * Plays raw signed PCM samples, returning a {@link Playback} handle that can stop it early.
+	 * Unlike the file and stream overloads this requires no decodable audio-file container, so it
+	 * suits synthesized or otherwise in-memory PCM audio.
+	 *
+	 * <p>So that callers need not touch {@code javax.sound} at all, this reports a line that could
+	 * not be opened by returning {@code null} rather than throwing a checked sound exception.
+	 *
+	 * @param pcm            the signed PCM sample bytes
+	 * @param sampleRate     sample rate, in Hz
+	 * @param channels       channel count (1 for mono, 2 for stereo)
+	 * @param sampleSizeBits bits per sample (for example 16)
+	 * @param bigEndian      {@code true} if the samples are big-endian, {@code false} for little-endian
+	 * @param gain           gain (in dB) to apply to playback
+	 * @return a handle that stops the audio when {@link Playback#stop()} is called, or {@code null}
+	 *         if a line could not be opened for playback
+	 */
+	@Nullable
+	public Playback play(byte[] pcm, int sampleRate, int channels, int sampleSizeBits, boolean bigEndian, float gain)
+	{
+		AudioFormat format = new AudioFormat(sampleRate, sampleSizeBits, channels, true, bigEndian);
+		Clip clip;
+
+		try
+		{
+			clip = AudioSystem.getClip();
+			clip.open(format, pcm, 0, pcm.length);
+		}
+		catch (LineUnavailableException | RuntimeException e)
+		{
+			log.warn("Failed to play PCM audio: {}", e.getMessage());
+			return null;
+		}
+
+		if (gain != 0)
+		{
+			trySetGain(clip, gain);
+		}
+
+		// Release the line once playback finishes on its own; stopping early releases it via the
+		// returned handle instead.
+		clip.addLineListener(event ->
+		{
+			if (event.getType() == LineEvent.Type.STOP)
+			{
+				clip.close();
+			}
+		});
+
+		clip.start();
+
+		return () ->
+		{
+			if (clip.isOpen())
+			{
+				clip.stop();
+				clip.close();
+			}
+		};
 	}
 
 	private void trySetGain(DataLine line, float gain)


### PR DESCRIPTION
## What

Adds `AudioPlayer.play(byte[] pcm, int sampleRate, int channels, int sampleSizeBits, boolean bigEndian, float gain)`, which plays raw signed PCM and returns a small `Playback` handle whose `stop()` ends playback early.

## Why

`AudioPlayer` is a great way to keep plugins off `javax.sound` directly, and this widens the set of plugins that can use it. Today every `play(...)` overload runs `AudioSystem.getAudioInputStream(...)`, so it needs a decodable audio-file container (WAV/AIFF), and there's no way to stop a sound before it finishes. Plugins that **generate or stream** audio, for example text-to-speech, have raw PCM rather than a file, and they need to interrupt the current sound (a new line should cut off the previous one). Without this they fall back to `javax.sound` directly.

With this overload, callers pass the format as primitives and get back a RuneLite-owned `Playback` handle, so the plugin needs no `javax.sound` imports at all.

This came out of a Plugin Hub submission ([runelite/plugin-hub#13127](https://github.com/runelite/plugin-hub/pull/13127), a dialogue text-to-speech plugin) where the scan bot rightly flags direct `javax.sound` use and points at `AudioPlayer`. The plugin streams synthesized PCM and cuts a line off when the player advances dialogue, which the current `AudioPlayer` API can't express, hence this addition so it can move onto `AudioPlayer` as intended.

## Testing

- `./gradlew :client:compileJava` and `:client:checkstyleMain` pass with the change.

- **Standalone runtime smoke** against a `new AudioPlayer()` on real audio hardware: generated a 440 Hz tone as raw signed 16-bit mono PCM and exercised the new overload end to end:

  ```
  play() returned non-null handle: true
  interrupted a 2s tone at 500ms (Playback.stop worked)
  second play() (with -6dB gain) handle non-null: true
  RESULT: play + stop + play-to-completion all succeeded, no exceptions
  ```

  This confirms `play(...)` opens a line for raw PCM (no file container), `Playback.stop()` cuts a sound off early, gain is applied, and playback-to-completion releases the line cleanly.

- **End-to-end in a real RuneLite dev client.** I built this branch, published it to `mavenLocal`, and pointed the text-to-speech plugin from the linked Hub submission at it, migrating that plugin off direct `javax.sound` and onto `AudioPlayer.play(byte[], ...)` + `Playback.stop()`. In-game I talked to a range of NPCs across both of the plugin's audio backends: ~20 lines were synthesized and played through the new overload with **no `AudioPlayer` errors and no exceptions** in the client log, and advancing/skipping dialogue cut the current line off cleanly via `Playback.stop()`. Manually verified by ear that audio plays and that interruption on skip works.

- The migrated plugin compiles with **zero `javax.sound` references in its bytecode** (verified by scanning the built jar), which is the outcome this overload is meant to enable.

## Design notes / open to feedback

- **Primitives, not `AudioFormat`.** Accepting an `AudioFormat` would pull callers back into `javax.sound`, defeating the purpose, hence `(sampleRate, channels, sampleSizeBits, bigEndian)`. Samples are assumed signed (the common PCM case); glad to add a `signed` flag if you'd prefer.
- **Returns `null` instead of throwing.** The existing overloads throw checked `javax.sound` exceptions, but since the point here is to keep callers off `javax.sound` entirely, this logs and returns `null` when a line can't be opened, so nothing `javax.sound` reaches the caller. Happy to make it throw for consistency if you'd rather.
- **`Clip`-based**, matching the existing overloads: `clip.open(format, bytes, 0, len)` plays raw PCM with no container. Buffers per call, which is fine for finite lines; a streaming `SourceDataLine` variant could follow if it's ever wanted.
- **`Playback` handle** rather than returning the `Clip` (which would re-expose `javax.sound`) or a global `stop()` on the singleton (which would cut unrelated plugins' audio). Could extend `AutoCloseable` instead if you prefer try-with-resources; `stop()` reads better for held-handle audio use.
- **Method name**: overloaded `play` for consistency; happy to rename to `playPcm` if the differing return type is confusing.
- **No unit test**: opening a real line needs audio hardware that headless CI lacks, matching this file's current lack of tests. Verified locally that `:client:compileJava` and `:client:checkstyleMain` pass, and end-to-end against the real plugin (see below).

Happy to adjust any of the above, this is my first contribution here and I want it to fit your conventions.
