### PR TITLE
Adds a hotkey to display item equipment stats on item hover

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -28,6 +28,7 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Keybind;
 
 @ConfigGroup("itemstat")
 public interface ItemStatConfig extends Config
@@ -50,6 +51,16 @@ public interface ItemStatConfig extends Config
 	default boolean equipmentStats()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = "equipmentStatsHotkey",
+		name = "Equipment stats hotkey",
+		description = "Hold this hotkey to show equipment stats tooltips when hovering over items."
+	)
+	default Keybind equipmentStatsHotkey()
+	{
+		return Keybind.NOT_SET;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -75,6 +75,13 @@ public class ItemStatOverlay extends Overlay
 	@Inject
 	private ItemStatConfig config;
 
+	private boolean equipmentStatsHotkeyPressed;
+
+	void setEquipmentStatsHotkeyPressed(boolean equipmentStatsHotkeyPressed)
+	{
+		this.equipmentStatsHotkeyPressed = equipmentStatsHotkeyPressed;
+	}
+
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
@@ -185,7 +192,7 @@ public class ItemStatOverlay extends Overlay
 			}
 		}
 
-		if (config.equipmentStats())
+		if (config.equipmentStats() || equipmentStatsHotkeyPressed)
 		{
 			final ItemStats stats = itemManager.getItemStats(itemId);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
@@ -59,11 +59,13 @@ import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.ItemEquipmentStats;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStats;
+import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.JagexColors;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.HotkeyListener;
 import net.runelite.client.util.QuantityFormatter;
 
 @PluginDescriptor(
@@ -95,7 +97,25 @@ public class ItemStatPlugin extends Plugin
 	@Inject
 	private ClientThread clientThread;
 
+	@Inject
+	private KeyManager keyManager;
+
 	private Widget itemInformationTitle;
+
+	private final HotkeyListener equipmentStatsHotkeyListener = new HotkeyListener(() -> config.equipmentStatsHotkey())
+	{
+		@Override
+		public void hotkeyPressed()
+		{
+			overlay.setEquipmentStatsHotkeyPressed(true);
+		}
+
+		@Override
+		public void hotkeyReleased()
+		{
+			overlay.setEquipmentStatsHotkeyPressed(false);
+		}
+	};
 
 	@Provides
 	ItemStatConfig getConfig(ConfigManager configManager)
@@ -113,12 +133,15 @@ public class ItemStatPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		overlayManager.add(overlay);
+		keyManager.registerKeyListener(equipmentStatsHotkeyListener);
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
 		overlayManager.remove(overlay);
+		keyManager.unregisterKeyListener(equipmentStatsHotkeyListener);
+		overlay.setEquipmentStatsHotkeyPressed(false);
 		clientThread.invokeLater(this::resetGEInventory);
 	}
 


### PR DESCRIPTION
Holding the hotkey shows equipment stats overlay when hovering over an item
releasing it hides the overlay