### PR TITLE
feat(plugin,music): lower volume on client window focus loss

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicConfig.java
@@ -100,4 +100,15 @@ public interface MusicConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "muteMusicOnFocusLoss",
+		name = "Lower volume on focus loss",
+		description = "Lower music volume when the client window is not focused.",
+		position = 6
+	)
+	default boolean muteMusicOnFocusLoss()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -42,6 +42,7 @@ import net.runelite.api.Player;
 import net.runelite.api.SoundEffectID;
 import net.runelite.api.events.AmbientSoundEffectCreated;
 import net.runelite.api.events.AreaSoundEffectPlayed;
+import net.runelite.api.events.FocusChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.api.events.SoundEffectPlayed;
@@ -130,6 +131,8 @@ public class MusicPlugin extends Plugin
 
 	@Nullable
 	private MusicState currentMusicFilter = null;
+
+	private int preFocusLossMusicVolume = -1;
 
 	@Override
 	protected void startUp()
@@ -460,5 +463,34 @@ public class MusicPlugin extends Plugin
 		{
 			client.getAmbientSoundEffects().clear();
 		}
+	}
+
+	@Subscribe
+	public void onFocusChanged(FocusChanged focusChanged)
+	{
+		if (!musicConfig.muteMusicOnFocusLoss())
+		{
+			return;
+		}
+
+		clientThread.invoke(() ->
+		{
+			if (!focusChanged.isFocused())
+			{
+				if (preFocusLossMusicVolume == -1)
+				{
+					preFocusLossMusicVolume = client.getMusicVolume();
+					// Use minimum non-zero value to keep music stream alive.
+					// Setting to 0 stops the current track entirely & the game will not
+					// resume playback.
+					client.setMusicVolume(1);
+				}
+			}
+			else if (preFocusLossMusicVolume != -1)
+			{
+				client.setMusicVolume(preFocusLossMusicVolume);
+				preFocusLossMusicVolume = -1;
+			}
+		});
 	}
 }


### PR DESCRIPTION
Added checkbox to Music plugin to lower music volume when client window goes out of focus:
<img width="223" height="249" alt="image" src="https://github.com/user-attachments/assets/6b392ef7-a85b-4c3f-be63-807f690641e9" />
