### PR TITLE
bank tags: Add option to place items in bank but not in layout at the end of the layout

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsService.java
@@ -49,6 +49,10 @@ public interface BankTagsService
 	 * Option to prevent {@link #openBankTag(String, int)} from performing a layout
 	 */
 	int OPTION_NO_LAYOUT = 0x4;
+	/**
+	 * Option to put items in the bank but not in the layout at the bottom
+	 */
+	int OPTION_ITEMS_NOT_IN_LAYOUT_AT_BOTTOM = 0x8;
 
 	/**
 	 * Open the given bank tag. The tag may have an associated {@link net.runelite.client.plugins.banktags.tabs.TagTab},

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/Layout.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/Layout.java
@@ -197,4 +197,16 @@ public class Layout
 		}
 		layout = n;
 	}
+
+	int lastItemIndex()
+	{
+		for (int i = layout.length - 1; i >= 0; --i)
+		{
+			if (layout[i] != -1)
+			{
+				return i;
+			}
+		}
+		return -1;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java
@@ -272,24 +272,24 @@ public class LayoutManager
 			drawItem(l, c, bank, bankItemId, pos);
 		}
 
-		int lastEmptySlot = -1;
+		int insertionSlot = (plugin.getOptions() & BankTagsService.OPTION_ITEMS_NOT_IN_LAYOUT_AT_BOTTOM) != 0 ? l.lastItemIndex() : -1;
 		boolean modified = false;
 		// Items from the bank but not in the layout.
 		for (int itemId : bankItems)
 		{
 			do
 			{
-				++lastEmptySlot;
+				++insertionSlot;
 			}
-			while (lastEmptySlot < layout.length && layout[lastEmptySlot] > -1);
+			while (l.getItemAtPos(insertionSlot) > -1);
 
-			Widget c = itemContainer.getChild(lastEmptySlot);
+			Widget c = itemContainer.getChild(insertionSlot);
 			if (c == null || c.getOriginalHeight() != BANK_ITEM_HEIGHT) // check for tabs
 			{
 				break;
 			}
 
-			drawItem(l, c, bank, itemId, lastEmptySlot);
+			drawItem(l, c, bank, itemId, insertionSlot);
 
 			if (log.isDebugEnabled())
 			{
@@ -300,26 +300,27 @@ public class LayoutManager
 			}
 
 			int layoutItemId = itemManager.canonicalize(itemId);
-			l.addItem(layoutItemId);
+			l.addItemAfter(layoutItemId, insertionSlot);
 			modified = true;
 		}
 
 		// Fill the remaining slots with -1 so that items can be dragged to them
+		insertionSlot = -1;
 		while (true)
 		{
 			do
 			{
-				++lastEmptySlot;
+				++insertionSlot;
 			}
-			while (lastEmptySlot < layout.length && layout[lastEmptySlot] > -1);
+			while (l.getItemAtPos(insertionSlot) > -1);
 
-			Widget c = itemContainer.getChild(lastEmptySlot);
+			Widget c = itemContainer.getChild(insertionSlot);
 			if (c == null || c.getOriginalHeight() != BANK_ITEM_HEIGHT)  // check for tabs
 			{
 				break;
 			}
 
-			drawItem(l, c, bank, -1, lastEmptySlot);
+			drawItem(l, c, bank, -1, insertionSlot);
 		}
 
 		if (modified)


### PR DESCRIPTION
Add a `BankTagsService` option to place items in the bank but not in the layout at the end of layout. This is relevant for variation items. When variation via `*` is added to a tag, the items would normally appear in the first available empty slot in the layout. This can clutter layouts that place items in particular patterns like `ZigZag` or `Preset`. To minimize this, an option to place those items at the bottom of the layout is added for plugins to use when interfacing with `BankTagsService`.

---

Example:

Before, the attack potion variations appear at the top of the layout:
<img width="765" height="503" alt="before" src="https://github.com/user-attachments/assets/49e9a89d-d89e-4adb-a92f-93c7b3d4d869" />

After, the attack potion variations appear at the end of the layout:
<img width="765" height="503" alt="after" src="https://github.com/user-attachments/assets/afb9fd68-36b9-4d4d-a141-cc368034f07f" />

---

My main motivation for this change is to use this in Inventory Setups. Currently I have some logic to add the variation items to the bottom of the layout before bank tags gets a chance to do it. It doesn't really interact well and it's definitely not performant. Since Bank Tags is already doing this work of computing items in the bank but not in the layout, adding an option here would keep the behavior between the two plugins a little more in sync, allow me to remove a bunch of crappy code, and fix the "fuzzy" feature that has been sort of broken since I integrated the core layout API into Inventory Setups over a year and a half ago.

Open to changing the name of the option or other implementation details as needed. As can be seen, I changed the return type of `Layout.addItem` and its variants to return the index that was changed to streamline this option.