### PR TITLE
loottracker: Track seeds sent to seed box

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -163,6 +163,9 @@ public class LootTrackerPlugin extends Plugin
 	private static final String HERBIBOAR_EVENT = "Herbiboar";
 	private static final Pattern HERBIBOAR_HERB_SACK_PATTERN = Pattern.compile(".+(Grimy .+?) herb.+");
 
+	// Master Farmer loot handling
+	private static final Pattern MASTER_FARMER_SEED_BOX_PATTERN = Pattern.compile("The following stolen loot gets added to your seed box: (.+?) x (\\d+)\\.");
+
 	// Zombie Pirate Locker loot handling
 	static final String ZOMBIE_PIRATE_LOCKER_EVENT = "Zombie Pirate's Locker";
 	private static final Pattern ZOMBIE_PIRATE_LOCKER_PATTERN = Pattern.compile("You loot the locker and receive <col=[\\da-f]{6}>(?<qty>[\\d,]+) x (?<item>.+)</col>\\.");
@@ -1056,6 +1059,13 @@ public class LootTrackerPlugin extends Plugin
 			return;
 		}
 
+		Matcher seedBoxMatcher = MASTER_FARMER_SEED_BOX_PATTERN.matcher(message);
+		if (seedBoxMatcher.matches())
+		{
+			processMasterFarmerSeedBoxLoot(seedBoxMatcher);
+			return;
+		}
+
 		final Matcher pickpocketMatcher = PICKPOCKET_REGEX.matcher(message);
 		if (pickpocketMatcher.matches())
 		{
@@ -1520,6 +1530,16 @@ public class LootTrackerPlugin extends Plugin
 		return true;
 	}
 
+	private boolean processMasterFarmerSeedBoxLoot(Matcher matcher)
+	{
+		int quantityStolen = Integer.parseInt(matcher.group(2));
+		List<ItemStack> seeds = Collections.singletonList(new ItemStack(itemManager.search(matcher.group(1)).get(0).getId(), quantityStolen, client.getLocalPlayer().getLocalLocation()));
+
+		int thievingLevelLevel = client.getBoostedSkillLevel(Skill.THIEVING);
+		addLoot(lastPickpocketTarget, -1, LootRecordType.PICKPOCKET, thievingLevelLevel, seeds);
+		return true;
+	}
+
 	private void processZombiePirateLockerLoot(Matcher matcher)
 	{
 		final int quantity = Integer.parseInt(matcher.group("qty").replaceAll(",", ""));
@@ -1721,3 +1741,4 @@ public class LootTrackerPlugin extends Plugin
 		}
 	}
 }
+

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -164,7 +164,8 @@ public class LootTrackerPlugin extends Plugin
 	private static final Pattern HERBIBOAR_HERB_SACK_PATTERN = Pattern.compile(".+(Grimy .+?) herb.+");
 
 	// Master Farmer loot handling
-	private static final Pattern MASTER_FARMER_SEED_BOX_PATTERN = Pattern.compile("The following stolen loot gets added to your seed box: (.+?) x (\\d+)\\.");
+	private static final Pattern MASTER_FARMER_SEED_BOX_MULTIPLE_PATTERN = Pattern.compile("The following stolen loot gets added to your seed box: (.+?) x (\\d+)\\.");
+	private static final Pattern MASTER_FARMER_SEED_BOX_SINGLE_PATTERN = Pattern.compile("You put the stolen (.+?) into your seed box\\.");
 
 	// Zombie Pirate Locker loot handling
 	static final String ZOMBIE_PIRATE_LOCKER_EVENT = "Zombie Pirate's Locker";
@@ -1059,10 +1060,16 @@ public class LootTrackerPlugin extends Plugin
 			return;
 		}
 
-		Matcher seedBoxMatcher = MASTER_FARMER_SEED_BOX_PATTERN.matcher(message);
-		if (seedBoxMatcher.matches())
+		Matcher multiSeedBoxMatcher = MASTER_FARMER_SEED_BOX_MULTIPLE_PATTERN.matcher(message);
+		if (multiSeedBoxMatcher.matches())
 		{
-			processMasterFarmerSeedBoxLoot(seedBoxMatcher);
+			processMasterFarmerSeedBoxLoot(multiSeedBoxMatcher.group(1), Integer.parseInt(multiSeedBoxMatcher.group(2)));
+			return;
+		}
+		Matcher singleSeedBoxMatcher = MASTER_FARMER_SEED_BOX_SINGLE_PATTERN.matcher(message);
+		if (singleSeedBoxMatcher.matches())
+		{
+			processMasterFarmerSeedBoxLoot(singleSeedBoxMatcher.group(1), 1);
 			return;
 		}
 
@@ -1530,10 +1537,9 @@ public class LootTrackerPlugin extends Plugin
 		return true;
 	}
 
-	private void processMasterFarmerSeedBoxLoot(Matcher matcher)
+	private void processMasterFarmerSeedBoxLoot(String itemName, int quantityStolen)
 	{
-		int quantityStolen = Integer.parseInt(matcher.group(2));
-		List<ItemStack> seeds = Collections.singletonList(new ItemStack(itemManager.search(matcher.group(1)).get(0).getId(), quantityStolen, client.getLocalPlayer().getLocalLocation()));
+		List<ItemStack> seeds = Collections.singletonList(new ItemStack(itemManager.search(itemName).get(0).getId(), quantityStolen, client.getLocalPlayer().getLocalLocation()));
 
 		addLoot(lastPickpocketTarget, -1, LootRecordType.PICKPOCKET, client.getBoostedSkillLevel(Skill.THIEVING), seeds);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -1530,14 +1530,12 @@ public class LootTrackerPlugin extends Plugin
 		return true;
 	}
 
-	private boolean processMasterFarmerSeedBoxLoot(Matcher matcher)
+	private void processMasterFarmerSeedBoxLoot(Matcher matcher)
 	{
 		int quantityStolen = Integer.parseInt(matcher.group(2));
 		List<ItemStack> seeds = Collections.singletonList(new ItemStack(itemManager.search(matcher.group(1)).get(0).getId(), quantityStolen, client.getLocalPlayer().getLocalLocation()));
 
-		int thievingLevelLevel = client.getBoostedSkillLevel(Skill.THIEVING);
-		addLoot(lastPickpocketTarget, -1, LootRecordType.PICKPOCKET, thievingLevelLevel, seeds);
-		return true;
+		addLoot(lastPickpocketTarget, -1, LootRecordType.PICKPOCKET, client.getBoostedSkillLevel(Skill.THIEVING), seeds);
 	}
 
 	private void processZombiePirateLockerLoot(Matcher matcher)
@@ -1741,4 +1739,3 @@ public class LootTrackerPlugin extends Plugin
 		}
 	}
 }
-

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -196,6 +196,29 @@ public class LootTrackerPluginTest
 	}
 
 	@Test
+	public void testPickPocketToSeedBox()
+	{
+		when(client.getBoostedSkillLevel(Skill.THIEVING)).thenReturn(42);
+
+		final ItemPrice seedPrice = new ItemPrice();
+		seedPrice.setId(5318);
+		seedPrice.setName("Potato seed");
+		when(itemManager.search("Potato seed")).thenReturn(Collections.singletonList(seedPrice));
+
+		LootTrackerPlugin lootTrackerPluginSpy = spy(this.lootTrackerPlugin);
+		doNothing().when(lootTrackerPluginSpy).addLoot(any(), anyInt(), any(), any(), any());
+
+
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", "The following stolen loot gets added to your seed box: Potato seed x 3.", "", 0);
+		lootTrackerPluginSpy.onChatMessage(chatMessage);
+
+
+		verify(lootTrackerPluginSpy).addLoot(null, -1, LootRecordType.PICKPOCKET, 42, Arrays.asList(
+				new ItemStack(5318, 3, null)
+		));
+	}
+
+	@Test
 	public void testFirstClue()
 	{
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "You have completed 1 master Treasure Trail.", "", 0);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -212,7 +212,7 @@ public class LootTrackerPluginTest
 		lootTrackerPluginSpy.onChatMessage(chatMessage);
 
 		verify(lootTrackerPluginSpy).addLoot(null, -1, LootRecordType.PICKPOCKET, 42, Arrays.asList(
-				new ItemStack(ItemID.POTATO_SEED, 3, null)
+			new ItemStack(ItemID.POTATO_SEED, 3, null)
 		));
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -200,19 +200,29 @@ public class LootTrackerPluginTest
 	{
 		when(client.getBoostedSkillLevel(Skill.THIEVING)).thenReturn(42);
 
-		final ItemPrice seedPrice = new ItemPrice();
-		seedPrice.setId(ItemID.POTATO_SEED);
-		seedPrice.setName("Potato seed");
-		when(itemManager.search("Potato seed")).thenReturn(Collections.singletonList(seedPrice));
+		final ItemPrice potatoSeedPrice = new ItemPrice();
+		potatoSeedPrice.setId(ItemID.POTATO_SEED);
+		potatoSeedPrice.setName("Potato seed");
+		when(itemManager.search("Potato seed")).thenReturn(Collections.singletonList(potatoSeedPrice));
+		final ItemPrice onionSeedPrice = new ItemPrice();
+		onionSeedPrice.setId(ItemID.ONION_SEED);
+		onionSeedPrice.setName("Onion seed");
+		when(itemManager.search("Onion seed")).thenReturn(Collections.singletonList(onionSeedPrice));
 
 		LootTrackerPlugin lootTrackerPluginSpy = spy(this.lootTrackerPlugin);
 		doNothing().when(lootTrackerPluginSpy).addLoot(any(), anyInt(), any(), any(), any());
 
-		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", "The following stolen loot gets added to your seed box: Potato seed x 3.", "", 0);
-		lootTrackerPluginSpy.onChatMessage(chatMessage);
+		ChatMessage chatMessageMultipleSeeds = new ChatMessage(null, ChatMessageType.SPAM, "", "The following stolen loot gets added to your seed box: Potato seed x 3.", "", 0);
+		lootTrackerPluginSpy.onChatMessage(chatMessageMultipleSeeds);
+
+		ChatMessage chatMessageSingleSeeds = new ChatMessage(null, ChatMessageType.SPAM, "", "You put the stolen Onion seed into your seed box.", "", 0);
+		lootTrackerPluginSpy.onChatMessage(chatMessageSingleSeeds);
 
 		verify(lootTrackerPluginSpy).addLoot(null, -1, LootRecordType.PICKPOCKET, 42, Arrays.asList(
 			new ItemStack(ItemID.POTATO_SEED, 3, null)
+		));
+		verify(lootTrackerPluginSpy).addLoot(null, -1, LootRecordType.PICKPOCKET, 42, Arrays.asList(
+				new ItemStack(ItemID.ONION_SEED, 1, null)
 		));
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -201,20 +201,18 @@ public class LootTrackerPluginTest
 		when(client.getBoostedSkillLevel(Skill.THIEVING)).thenReturn(42);
 
 		final ItemPrice seedPrice = new ItemPrice();
-		seedPrice.setId(5318);
+		seedPrice.setId(ItemID.POTATO_SEED);
 		seedPrice.setName("Potato seed");
 		when(itemManager.search("Potato seed")).thenReturn(Collections.singletonList(seedPrice));
 
 		LootTrackerPlugin lootTrackerPluginSpy = spy(this.lootTrackerPlugin);
 		doNothing().when(lootTrackerPluginSpy).addLoot(any(), anyInt(), any(), any(), any());
 
-
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", "The following stolen loot gets added to your seed box: Potato seed x 3.", "", 0);
 		lootTrackerPluginSpy.onChatMessage(chatMessage);
 
-
 		verify(lootTrackerPluginSpy).addLoot(null, -1, LootRecordType.PICKPOCKET, 42, Arrays.asList(
-				new ItemStack(5318, 3, null)
+				new ItemStack(ItemID.POTATO_SEED, 3, null)
 		));
 	}
 


### PR DESCRIPTION
Revives #13716.

Original work by @Patrick852

When pickpocketing a master farmer with an open seed sack seeds sent to seed box are not tracked by loot tracker. This commit adds support for reading those chat messages when
pick pocketed seeds go to the seed box.

partially resolves #11290 