### PR TITLE
Boosts Information - new Str,Range,Mage option + use correct base Level inside LMS

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostIndicator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostIndicator.java
@@ -60,7 +60,7 @@ class BoostIndicator extends InfoBox
 			return String.valueOf(client.getBoostedSkillLevel(skill));
 		}
 
-		int boost = client.getBoostedSkillLevel(skill) - client.getRealSkillLevel(skill);
+		int boost = client.getBoostedSkillLevel(skill) - CombatLevelsProvider.getRealSkillLevel(client, skill);
 		String text = String.valueOf(boost);
 		if (boost > 0)
 		{
@@ -74,7 +74,7 @@ class BoostIndicator extends InfoBox
 	public Color getTextColor()
 	{
 		int boosted = client.getBoostedSkillLevel(skill),
-			base = client.getRealSkillLevel(skill);
+			base = CombatLevelsProvider.getRealSkillLevel(client, skill);
 
 		if (boosted < base)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
@@ -24,6 +24,12 @@
  */
 package net.runelite.client.plugins.boosts;
 
+import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import net.runelite.api.Skill;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -41,10 +47,54 @@ public interface BoostsConfig extends Config
 
 	enum DisplayBoosts
 	{
-		NONE,
-		COMBAT,
-		NON_COMBAT,
-		BOTH
+		NONE("None", Collections.EMPTY_SET),
+		COMBAT("Combat", DisplayBoostSkills.BOOSTABLE_COMBAT_SKILLS),
+		NON_COMBAT("Non Combat", DisplayBoostSkills.BOOSTABLE_NON_COMBAT_SKILLS),
+		ALL("All", DisplayBoostSkills.ALL_BOOSTABLE_SKILLS),
+
+		// STR_RANGE_MAGE: Similar to Combat, but without attack & defence. In both PvM & PvP, odds are that you're
+		// gonna be using a mixture of super combat potions & saradomin brews, which means that knowing your attack
+		// & defence boosts doesn't give you any more info than knowing your Strength boost.
+		STR_RANGE_MAGE("Str, Range, Mage", DisplayBoostSkills.STR_RANGE_MAGE);
+
+		String name;
+		Set<Skill> skillsToDisplay;
+
+		DisplayBoosts(String name, Set<Skill> skillsToDisplay)
+		{
+			this.name = name;
+			this.skillsToDisplay = skillsToDisplay;
+		}
+
+		@Override
+		public String toString()
+		{
+			return this.name;
+		}
+	}
+	// use static class for these constants since we can't put these directly in DisplayBoosts,
+	// can't use enum static fields in their own init.
+	class DisplayBoostSkills
+	{
+		public static final Set<Skill> BOOSTABLE_COMBAT_SKILLS = ImmutableSet.of(
+			Skill.ATTACK,
+			Skill.STRENGTH,
+			Skill.DEFENCE,
+			Skill.RANGED,
+			Skill.MAGIC);
+		public static final Set<Skill> BOOSTABLE_NON_COMBAT_SKILLS = ImmutableSet.of(
+			Skill.MINING, Skill.AGILITY, Skill.SMITHING, Skill.HERBLORE, Skill.FISHING, Skill.THIEVING,
+			Skill.COOKING, Skill.CRAFTING, Skill.FIREMAKING, Skill.FLETCHING, Skill.WOODCUTTING, Skill.RUNECRAFT,
+			Skill.SLAYER, Skill.FARMING, Skill.CONSTRUCTION, Skill.HUNTER, Skill.SAILING);
+
+		public static final Set<Skill> ALL_BOOSTABLE_SKILLS = Stream.concat(
+			BOOSTABLE_COMBAT_SKILLS.stream(), BOOSTABLE_NON_COMBAT_SKILLS.stream()
+		).collect(Collectors.toSet());
+
+		public static final Set<Skill> STR_RANGE_MAGE = ImmutableSet.of(
+			Skill.STRENGTH,
+			Skill.RANGED,
+			Skill.MAGIC);
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
@@ -83,7 +83,7 @@ class BoostsOverlay extends OverlayPanel
 		for (Skill skill : boostedSkills)
 		{
 			final int boosted = client.getBoostedSkillLevel(skill);
-			final int base = client.getRealSkillLevel(skill);
+			final int base = CombatLevelsProvider.getRealSkillLevel(client, skill);
 			final int boost = boosted - base;
 			final Color strColor = getTextColor(boost);
 			String str;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -41,6 +41,7 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.StatChanged;
 import net.runelite.client.Notifier;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.Notification;
 import net.runelite.client.eventbus.Subscribe;
@@ -68,6 +69,9 @@ public class BoostsPlugin extends Plugin
 
 	@Inject
 	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
 
 	@Inject
 	private InfoBoxManager infoBoxManager;
@@ -233,7 +237,7 @@ public class BoostsPlugin extends Plugin
 
 		int boostThreshold = config.boostThreshold();
 
-		int real = client.getRealSkillLevel(skill);
+		int real = CombatLevelsProvider.getRealSkillLevel(client, skill);
 		int lastBoost = last - real;
 		int boost = cur - real;
 		if (boost <= boostThreshold && boostThreshold < lastBoost)
@@ -307,21 +311,23 @@ public class BoostsPlugin extends Plugin
 			}
 
 			final int boosted = client.getBoostedSkillLevel(skill);
-			final int base = client.getRealSkillLevel(skill);
+			clientThread.invokeLater(() ->
+			{
+				final int base = CombatLevelsProvider.getRealSkillLevel(client, skill);
+				if (boosted > base)
+				{
+					isChangedUp = true;
+				}
+				else if (boosted < base)
+				{
+					isChangedDown = true;
+				}
 
-			if (boosted > base)
-			{
-				isChangedUp = true;
-			}
-			else if (boosted < base)
-			{
-				isChangedDown = true;
-			}
-
-			if (boosted != base)
-			{
-				skillsToDisplay.add(skill);
-			}
+				if (boosted != base)
+				{
+					skillsToDisplay.add(skill);
+				}
+			});
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -24,7 +24,6 @@
  */
 package net.runelite.client.plugins.boosts;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -64,18 +63,6 @@ import net.runelite.client.util.ImageUtil;
 @Slf4j
 public class BoostsPlugin extends Plugin
 {
-	private static final Set<Skill> BOOSTABLE_COMBAT_SKILLS = ImmutableSet.of(
-		Skill.ATTACK,
-		Skill.STRENGTH,
-		Skill.DEFENCE,
-		Skill.RANGED,
-		Skill.MAGIC);
-
-	private static final Set<Skill> BOOSTABLE_NON_COMBAT_SKILLS = ImmutableSet.of(
-		Skill.MINING, Skill.AGILITY, Skill.SMITHING, Skill.HERBLORE, Skill.FISHING, Skill.THIEVING,
-		Skill.COOKING, Skill.CRAFTING, Skill.FIREMAKING, Skill.FLETCHING, Skill.WOODCUTTING, Skill.RUNECRAFT,
-		Skill.SLAYER, Skill.FARMING, Skill.CONSTRUCTION, Skill.HUNTER, Skill.SAILING);
-
 	@Inject
 	private Notifier notifier;
 
@@ -220,7 +207,7 @@ public class BoostsPlugin extends Plugin
 	{
 		Skill skill = statChanged.getSkill();
 
-		if (!BOOSTABLE_COMBAT_SKILLS.contains(skill) && !BOOSTABLE_NON_COMBAT_SKILLS.contains(skill))
+		if (!config.displayBoosts().skillsToDisplay.contains(skill))
 		{
 			return;
 		}
@@ -299,25 +286,8 @@ public class BoostsPlugin extends Plugin
 
 	private void updateShownSkills()
 	{
-		switch (config.displayBoosts())
-		{
-			case NONE:
-				shownSkills.removeAll(BOOSTABLE_COMBAT_SKILLS);
-				shownSkills.removeAll(BOOSTABLE_NON_COMBAT_SKILLS);
-				break;
-			case COMBAT:
-				shownSkills.addAll(BOOSTABLE_COMBAT_SKILLS);
-				shownSkills.removeAll(BOOSTABLE_NON_COMBAT_SKILLS);
-				break;
-			case NON_COMBAT:
-				shownSkills.removeAll(BOOSTABLE_COMBAT_SKILLS);
-				shownSkills.addAll(BOOSTABLE_NON_COMBAT_SKILLS);
-				break;
-			case BOTH:
-				shownSkills.addAll(BOOSTABLE_COMBAT_SKILLS);
-				shownSkills.addAll(BOOSTABLE_NON_COMBAT_SKILLS);
-				break;
-		}
+		shownSkills.clear();
+		shownSkills.addAll(config.displayBoosts().skillsToDisplay);
 		updateBoostedStats();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/CombatLevelsProvider.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/CombatLevelsProvider.java
@@ -59,6 +59,11 @@ public class CombatLevelsProvider
 			return this.levels.get(skill);
 		}
 
+		public boolean containsKey(Skill skill)
+		{
+			return this.levels.containsKey(skill);
+		}
+
 
 		static LmsBuildLevels getCurrent(Client client)
 		{
@@ -74,7 +79,7 @@ public class CombatLevelsProvider
 	public static int getRealSkillLevel(Client client, Skill skill)
 	{
 		LmsBuildLevels levels;
-		if (isInLmsMatch(client) && (levels = LmsBuildLevels.getCurrent(client)) != null)
+		if (isInLmsMatch(client) && (levels = LmsBuildLevels.getCurrent(client)) != null && levels.containsKey(skill))
 		{
 			return levels.get(skill);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/CombatLevelsProvider.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/CombatLevelsProvider.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026, Matsyir <https://github.com/matsyir>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.boosts;
+
+import java.util.HashMap;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import net.runelite.api.gameval.VarbitID;
+
+// Essentially a wrapper to replace calls to client.getRealSkillLevel with, in order
+// to return LMS' build levels instead if we are in an LMS match.
+//
+// use CombatLevelsProvider.getRealSkillLevel(client, skill) instead of client.getRealSkillLevel(skill)
+public class CombatLevelsProvider
+{
+	private enum LmsBuildLevels
+	{
+		// https://oldschool.runescape.wiki/w/Last_Man_Standing#Gameplay
+		LMS_MAXMED(0, 99, 99, 85, 99, 99),
+		LMS_ZERK(1, 80, 99, 50, 99, 99),
+		LMS_1DEF(2, 75, 99, 1, 99, 99);
+
+		final int activeBuildVarbitVal;
+		final HashMap<Skill, Integer> levels = new HashMap<>();
+		LmsBuildLevels(int activeBuildVarbitVal, int atk, int str, int def, int range, int mage)
+		{
+			this.activeBuildVarbitVal = activeBuildVarbitVal;
+			this.levels.put(Skill.ATTACK, atk);
+			this.levels.put(Skill.STRENGTH, str);
+			this.levels.put(Skill.DEFENCE, def);
+			this.levels.put(Skill.RANGED, range);
+			this.levels.put(Skill.MAGIC, mage);
+		}
+
+		public int get(Skill skill)
+		{
+			return this.levels.get(skill);
+		}
+
+
+		static LmsBuildLevels getCurrent(Client client)
+		{
+			int val = isInLmsMatch(client) ? client.getVarbitValue(VarbitID.BR_ACTIVE_BUILD_PLAYER) : -1;
+
+			return val == LmsBuildLevels.LMS_MAXMED.activeBuildVarbitVal ? LmsBuildLevels.LMS_MAXMED
+				: val == LmsBuildLevels.LMS_ZERK.activeBuildVarbitVal ? LmsBuildLevels.LMS_ZERK
+				: val == LmsBuildLevels.LMS_1DEF.activeBuildVarbitVal ? LmsBuildLevels.LMS_1DEF
+				: null;
+		}
+	}
+
+	public static int getRealSkillLevel(Client client, Skill skill)
+	{
+		LmsBuildLevels levels;
+		if (isInLmsMatch(client) && (levels = LmsBuildLevels.getCurrent(client)) != null)
+		{
+			return levels.get(skill);
+		}
+
+		return client.getRealSkillLevel(skill);
+	}
+
+
+	private static boolean isInLmsMatch(Client client)
+	{
+		return client.getVarbitValue(VarbitID.BR_INGAME) != 0;
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/CompactBoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/CompactBoostsOverlay.java
@@ -84,7 +84,7 @@ class CompactBoostsOverlay extends Overlay
 		for (Skill skill : boostedSkills)
 		{
 			final int boosted = client.getBoostedSkillLevel(skill);
-			final int base = client.getRealSkillLevel(skill);
+			final int base = CombatLevelsProvider.getRealSkillLevel(client, skill);
 			final int boost = boosted - base;
 
 			if (boost == 0)


### PR DESCRIPTION
New option, similar to combat, but hide Attack+Defence, since those are rarely relevant information due to the combined popularity of super combat potions & saradomin brews.

<img width="232" height="139" alt="image" src="https://github.com/user-attachments/assets/afb6c404-d21c-4d71-ac3f-612844f2726e" />


Particularly annoying for me, and I'm sure many others, is that when using this plugin in LMS, if you have a maxed account, you are going to constantly see a negative boost on defence & attack. Even in PvM though, I can't really think of a situation where your attack & defence boosts would be relevant to you on a max main using super combat pots and/or brews.

Here are some example screenshots

1def LMS match, with new config vs. with default Combat config (this occurs even on max/med due to the build being 85 defence)
<img width="942" height="720" alt="Screenshot 2026-07-08 133436" src="https://github.com/user-attachments/assets/99291545-c9f6-4e4c-be28-2f11d71f5679" />
<img width="855" height="696" alt="Screenshot 2026-07-08 133440" src="https://github.com/user-attachments/assets/a19ea7b4-2d4b-4d32-991f-5f8fa065e47b" />

Random bank screenshots outside of LMS
<img width="862" height="628" alt="Screenshot 2026-07-08 133348" src="https://github.com/user-attachments/assets/44936179-ec3f-471f-b12f-2d2a144e2c05" />
<img width="845" height="708" alt="Screenshot 2026-07-08 133340" src="https://github.com/user-attachments/assets/989845b2-cbef-48a7-8726-f7c1767f33f1" />

_Note: after taking those 4 screenshots, I overrode DisplayBoosts.toString() so that it shows `Str, Range, Mage` rather than just `Str Range Mage`, as seen in the inital screenshot above_

I haven't done a PR to core repo in over 5 years atp, let me know if there's any steps I forgot to take for this PR :)