### PR TITLE
motherlode: fix broken struts overlay early return

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSceneOverlay.java
@@ -81,11 +81,6 @@ class MotherlodeSceneOverlay extends Overlay
 			return null;
 		}
 
-		if (!config.showVeins() && !config.showRockFalls() && !config.showBrokenStruts())
-		{
-			return null;
-		}
-
 		Player local = client.getLocalPlayer();
 
 		renderTiles(graphics, local);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSceneOverlay.java
@@ -76,7 +76,12 @@ class MotherlodeSceneOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if ((!config.showVeins() && !config.showRockFalls()) || !plugin.isInMlm())
+		if (!plugin.isInMlm())
+		{
+			return null;
+		}
+
+		if (!config.showVeins() && !config.showRockFalls() && !config.showBrokenStruts())
 		{
 			return null;
 		}


### PR DESCRIPTION
The Motherlode overlay early return only checked veins + rocks, so with both off the whole overlay bailed even when broken struts were enabled.

Includes `showBrokenStruts` in that check. Object tracking for rocks vs struts was already correct.

Fixes #20172