### PR TITLE
clues: fix Burgh de rott coordinate clue

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -319,7 +319,7 @@ public class CoordinateClue extends ClueScroll implements LocationClueScroll
 			.build(),
 		CoordinateClue.builder()
 			.itemId(ItemID.TRAIL_HARD_SEXTANT_EXP5)
-			.location(new WorldPoint(3544, 3256, 0))
+			.location(new WorldPoint(3544, 3255, 0))
 			.directions("North-east of Burgh de Rott.")
 			.enemy(SARADOMIN_WIZARD)
 			.build(),


### PR DESCRIPTION
The current tile is blocked because of the the wyrd trapdoor since blood moon rises. The southern tile works instead.