### PR TITLE
loot tracker: add item value overrides

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -45,6 +45,7 @@ import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.SwingConstants;
@@ -77,6 +78,7 @@ class LootTrackerBox extends JPanel
 	private long totalPrice;
 	private final boolean hideIgnoredItems;
 	private final BiConsumer<String, Boolean> onItemToggle;
+	private final BiConsumer<String, Integer> onItemPriceOverride;
 
 	LootTrackerBox(
 		final ItemManager itemManager,
@@ -86,11 +88,13 @@ class LootTrackerBox extends JPanel
 		final boolean showPriceType,
 		final BiConsumer<String, Boolean> onItemToggle,
 		final BiConsumer<String, Boolean> onEventToggle,
+		final BiConsumer<String, Integer> onItemPriceOverride,
 		final boolean eventIgnored)
 	{
 		this.record = record;
 		this.itemManager = itemManager;
 		this.onItemToggle = onItemToggle;
+		this.onItemPriceOverride = onItemPriceOverride;
 		this.hideIgnoredItems = hideIgnoredItems;
 		this.priceType = priceType;
 		this.showPriceType = showPriceType;
@@ -150,6 +154,19 @@ class LootTrackerBox extends JPanel
 	boolean matches(final LootTrackerRecord r)
 	{
 		return r.getType() == record.getType() && r.getTitle().equals(record.getTitle());
+	}
+
+	/**
+	 * Checks if this box is backed by the exact given record instance, as opposed to
+	 * {@link #matches(LootTrackerRecord)} which only compares title and type and can
+	 * match multiple boxes in ungrouped view (e.g. repeat kills of the same NPC).
+	 *
+	 * @param r record to compare by identity
+	 * @return true if this box's underlying record is the same instance as r
+	 */
+	boolean isBackedBy(final LootTrackerRecord r)
+	{
+		return record == r;
 	}
 
 	/**
@@ -251,7 +268,7 @@ class LootTrackerBox extends JPanel
 						qty = Integer.MAX_VALUE;
 					}
 
-					return new LootTrackerItem(oldItem.getId(), oldItem.getName(), qty, oldItem.getGePrice(), oldItem.getHaPrice(), oldItem.isIgnored());
+					return new LootTrackerItem(oldItem.getId(), oldItem.getName(), qty, oldItem.getGePrice(), oldItem.getHaPrice(), oldItem.getCustomPrice(), oldItem.isIgnored());
 				},
 				LinkedHashMap::new
 			));
@@ -319,12 +336,58 @@ class LootTrackerBox extends JPanel
 				});
 
 				popupMenu.add(toggle);
+
+				final JMenuItem setValue = new JMenuItem(item.getCustomPrice() >= 0 ? "Edit custom value" : "Set custom value");
+				setValue.addActionListener(e -> promptForCustomPrice(item));
+				popupMenu.add(setValue);
+
+				if (item.getCustomPrice() >= 0)
+				{
+					final JMenuItem clearValue = new JMenuItem("Clear custom value");
+					clearValue.addActionListener(e -> onItemPriceOverride.accept(item.getName(), null));
+					popupMenu.add(clearValue);
+				}
 			}
 
 			itemContainer.add(slotContainer);
 		}
 
 		itemContainer.revalidate();
+	}
+
+	private void promptForCustomPrice(LootTrackerItem item)
+	{
+		final String currentValue = item.getCustomPrice() >= 0 ? String.valueOf(item.getCustomPrice()) : "";
+		final String input = JOptionPane.showInputDialog(this,
+			"Enter a custom value for " + item.getName() + ":", currentValue);
+
+		if (input == null)
+		{
+			return;
+		}
+
+		final String trimmed = input.trim();
+		if (trimmed.isEmpty())
+		{
+			onItemPriceOverride.accept(item.getName(), null);
+			return;
+		}
+
+		try
+		{
+			final int value = Integer.parseInt(trimmed);
+			if (value < 0)
+			{
+				JOptionPane.showMessageDialog(this, "Value must not be negative.", "Invalid value", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+
+			onItemPriceOverride.accept(item.getName(), value);
+		}
+		catch (NumberFormatException ex)
+		{
+			JOptionPane.showMessageDialog(this, "\"" + trimmed + "\" is not a valid whole number.", "Invalid value", JOptionPane.ERROR_MESSAGE);
+		}
 	}
 
 	private static String buildToolTip(LootTrackerItem item)
@@ -338,6 +401,17 @@ class LootTrackerBox extends JPanel
 		sb.append(name).append(" x ").append(QuantityFormatter.formatNumber(quantity)).append(ignoredLabel);
 		if (item.getId() == ItemID.COINS)
 		{
+			sb.append("</html>");
+			return sb.toString();
+		}
+
+		if (item.getCustomPrice() >= 0)
+		{
+			sb.append("<br>Custom value: ").append(QuantityFormatter.quantityToStackSize(gePrice));
+			if (quantity > 1)
+			{
+				sb.append(" (").append(QuantityFormatter.quantityToStackSize(item.getCustomPrice())).append(" ea)");
+			}
 			sb.append("</html>");
 			return sb.toString();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -82,6 +82,24 @@ public interface LootTrackerConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "itemValueOverrides",
+		name = "Item value overrides",
+		description = "Manually set the value of specific items, useful for untradeable items whose GE/HA price isn't accurate. Set via right-click on an item in the loot tracker, or bulk edit via 'Edit custom values...' on the totals bar.",
+		hidden = true
+	)
+	default String getItemValueOverrides()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		keyName = "itemValueOverrides",
+		name = "",
+		description = ""
+	)
+	void setItemValueOverrides(String key);
+
+	@ConfigItem(
 		keyName = "syncPanel",
 		name = "Remember loot",
 		description = "Saves loot between client sessions."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerItem.java
@@ -40,15 +40,17 @@ class LootTrackerItem
 	private final int gePrice;
 	private final int haPrice;
 	@Setter
+	private int customPrice;
+	@Setter
 	private boolean ignored;
 
 	long getTotalGePrice()
 	{
-		return (long) gePrice * quantity;
+		return (long) (customPrice >= 0 ? customPrice : gePrice) * quantity;
 	}
 
 	long getTotalHaPrice()
 	{
-		return (long) haPrice * quantity;
+		return (long) (customPrice >= 0 ? customPrice : haPrice) * quantity;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -25,6 +25,7 @@
  */
 package net.runelite.client.plugins.loottracker;
 
+import com.google.common.base.Splitter;
 import static com.google.common.collect.Iterables.concat;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -51,6 +52,8 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButton;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
 import javax.swing.JToggleButton;
 import javax.swing.border.EmptyBorder;
 import javax.swing.plaf.basic.BasicButtonUI;
@@ -64,6 +67,7 @@ import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.QuantityFormatter;
 import net.runelite.client.util.SwingUtil;
+import net.runelite.client.util.Text;
 import net.runelite.http.api.loottracker.LootRecordType;
 
 class LootTrackerPanel extends PluginPanel
@@ -338,13 +342,107 @@ class LootTrackerPanel extends PluginPanel
 			}
 		});
 
+		final JMenuItem editCustomValues = new JMenuItem("Edit custom values...");
+		editCustomValues.addActionListener(e -> showEditCustomValuesDialog(overallPanel));
+
 		// Create popup menu
 		final JPopupMenu popupMenu = new JPopupMenu();
 		popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
 		popupMenu.add(reset);
+		popupMenu.add(editCustomValues);
 		overallPanel.setComponentPopupMenu(popupMenu);
 
 		return overallPanel;
+	}
+
+	private static final Splitter LINE_SPLITTER = Splitter.on('\n').trimResults().omitEmptyStrings();
+
+	/**
+	 * Opens a dialog with a bulk text editor for the item value overrides, since the
+	 * raw config string is hidden from the settings UI in favor of right-click editing.
+	 */
+	private void showEditCustomValuesDialog(JPanel parent)
+	{
+		final List<String> currentEntries = Text.fromCSV(config.getItemValueOverrides());
+		final JTextArea textArea = new JTextArea(String.join("\n", currentEntries));
+		textArea.setRows(10);
+		textArea.setColumns(30);
+
+		final JPanel dialogPanel = new JPanel(new BorderLayout(0, 5));
+		dialogPanel.add(new JLabel("One itemName:value per line"), BorderLayout.NORTH);
+		dialogPanel.add(new JScrollPane(textArea), BorderLayout.CENTER);
+
+		final int result = JOptionPane.showConfirmDialog(parent, dialogPanel,
+			"Edit custom item values",
+			JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+
+		if (result != JOptionPane.OK_OPTION)
+		{
+			return;
+		}
+
+		final List<String> entries = new ArrayList<>();
+		final List<String> errors = new ArrayList<>();
+		for (String line : LINE_SPLITTER.split(textArea.getText()))
+		{
+			if (line.indexOf(',') != -1)
+			{
+				errors.add("\"" + line + "\" contains a comma, which is not allowed");
+				continue;
+			}
+
+			final int idx = line.lastIndexOf(':');
+			if (idx == -1)
+			{
+				errors.add("\"" + line + "\" is missing a \":\" separating the item name and value");
+				continue;
+			}
+
+			final String name = line.substring(0, idx).trim();
+			final String value = line.substring(idx + 1).trim();
+			if (name.isEmpty())
+			{
+				errors.add("\"" + line + "\" is missing an item name");
+				continue;
+			}
+
+			try
+			{
+				if (Integer.parseInt(value) < 0)
+				{
+					errors.add("\"" + line + "\" has a negative value");
+					continue;
+				}
+			}
+			catch (NumberFormatException e)
+			{
+				errors.add("\"" + line + "\" has an invalid value");
+				continue;
+			}
+
+			entries.add(name + ":" + value);
+		}
+
+		if (!errors.isEmpty())
+		{
+			JOptionPane.showMessageDialog(parent,
+				"Nothing was saved. Fix the following and try again:\n" + String.join("\n", errors),
+				"Invalid entries", JOptionPane.ERROR_MESSAGE);
+			return;
+		}
+
+		if (entries.isEmpty() && !currentEntries.isEmpty())
+		{
+			final int confirm = JOptionPane.showConfirmDialog(parent,
+				"This will remove all " + currentEntries.size() + " configured custom value(s). Continue?",
+				"Are you sure?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+			if (confirm != JOptionPane.YES_OPTION)
+			{
+				return;
+			}
+		}
+
+		config.setItemValueOverrides(Text.toCSV(entries));
 	}
 
 	void updateCollapseText()
@@ -502,6 +600,52 @@ class LootTrackerPanel extends PluginPanel
 	}
 
 	/**
+	 * After the item value overrides changed, iterate all the records and update
+	 * the custom price of all items of the same name. Only the boxes containing
+	 * a changed item are rebuilt, rather than the whole panel, since this can be
+	 * triggered by every edit to the overrides config.
+	 */
+	void updateCustomPrices()
+	{
+		List<LootTrackerRecord> changedRecords = new ArrayList<>();
+
+		for (LootTrackerRecord record : concat(aggregateRecords.values(), sessionRecords))
+		{
+			boolean recordChanged = false;
+
+			for (LootTrackerItem item : record.getItems())
+			{
+				int customPrice = plugin.getCustomPrice(item.getName());
+				if (item.getCustomPrice() != customPrice)
+				{
+					item.setCustomPrice(customPrice);
+					recordChanged = true;
+				}
+			}
+
+			if (recordChanged)
+			{
+				changedRecords.add(record);
+			}
+		}
+
+		if (changedRecords.isEmpty())
+		{
+			return;
+		}
+
+		for (LootTrackerBox box : boxes)
+		{
+			if (changedRecords.stream().anyMatch(box::isBackedBy))
+			{
+				box.rebuild();
+			}
+		}
+
+		updateOverall();
+	}
+
+	/**
 	 * Rebuilds all the boxes from scratch using existing listed records, depending on the grouping mode.
 	 */
 	void rebuild()
@@ -569,7 +713,8 @@ class LootTrackerPanel extends PluginPanel
 
 		// Create box
 		final LootTrackerBox box = new LootTrackerBox(itemManager, record,
-			hideIgnoredItems, config.priceType(), config.showPriceType(), plugin::toggleItem, plugin::toggleEvent, isIgnored);
+			hideIgnoredItems, config.priceType(), config.showPriceType(), plugin::toggleItem, plugin::toggleEvent,
+			plugin::setCustomPrice, isIgnored);
 
 		// Use the existing popup menu or create a new one
 		JPopupMenu popupMenu = box.getComponentPopupMenu();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -46,6 +46,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -390,6 +391,7 @@ public class LootTrackerPlugin extends Plugin
 
 	private List<String> ignoredItems = new ArrayList<>();
 	private List<String> ignoredEvents = new ArrayList<>();
+	private Map<String, Integer> itemValueOverrides = new LinkedHashMap<>();
 
 	private int inventoryId = -1;
 	private Multiset<Integer> inventorySnapshot;
@@ -585,6 +587,11 @@ public class LootTrackerPlugin extends Plugin
 			{
 				SwingUtilities.invokeLater(panel::rebuild);
 			}
+			else if ("itemValueOverrides".equals(event.getKey()))
+			{
+				itemValueOverrides = parseItemValueOverrides(config.getItemValueOverrides());
+				SwingUtilities.invokeLater(panel::updateCustomPrices);
+			}
 		}
 	}
 
@@ -594,6 +601,7 @@ public class LootTrackerPlugin extends Plugin
 		profileKey = null;
 		ignoredItems = Text.fromCSV(config.getIgnoredItems());
 		ignoredEvents = Text.fromCSV(config.getIgnoredEvents());
+		itemValueOverrides = parseItemValueOverrides(config.getItemValueOverrides());
 		panel = new LootTrackerPanel(this, itemManager, config);
 		spriteManager.getSpriteAsync(SpriteID.SideIcons.INVENTORY, 0, panel::loadHeaderIcon);
 
@@ -911,9 +919,7 @@ public class LootTrackerPlugin extends Plugin
 		{
 			long totalValue = items.stream()
 				.filter(item -> item.getId() > -1)
-				.mapToLong(item -> config.priceType() == LootTrackerPriceType.GRAND_EXCHANGE ?
-					(long) itemManager.getItemPrice(item.getId()) * item.getQuantity() :
-					(long) itemManager.getItemComposition(item.getId()).getHaPrice() * item.getQuantity())
+				.mapToLong(item -> (long) getItemValue(item.getId()) * item.getQuantity())
 				.sum();
 
 			String chatMessage = new ChatMessageBuilder()
@@ -1664,12 +1670,93 @@ public class LootTrackerPlugin extends Plugin
 		return ignoredEvents.contains(name);
 	}
 
+	int getCustomPrice(String name)
+	{
+		return itemValueOverrides.getOrDefault(name, -1);
+	}
+
+	void setCustomPrice(String name, Integer value)
+	{
+		final Map<String, Integer> overrides = new LinkedHashMap<>(itemValueOverrides);
+
+		if (value == null)
+		{
+			overrides.remove(name);
+		}
+		else
+		{
+			overrides.put(name, value);
+		}
+
+		final List<String> entries = new ArrayList<>();
+		for (Map.Entry<String, Integer> entry : overrides.entrySet())
+		{
+			entries.add(entry.getKey() + ":" + entry.getValue());
+		}
+
+		config.setItemValueOverrides(Text.toCSV(entries));
+		// the config changed will update the panel
+	}
+
+	private static Map<String, Integer> parseItemValueOverrides(String input)
+	{
+		final Map<String, Integer> overrides = new LinkedHashMap<>();
+
+		for (String entry : Text.fromCSV(input))
+		{
+			final int idx = entry.lastIndexOf(':');
+			if (idx == -1)
+			{
+				continue;
+			}
+
+			final String name = entry.substring(0, idx).trim();
+			final String value = entry.substring(idx + 1).trim();
+			if (name.isEmpty())
+			{
+				continue;
+			}
+
+			try
+			{
+				overrides.put(name, Integer.parseInt(value));
+			}
+			catch (NumberFormatException e)
+			{
+				log.debug("Invalid item value override: {}", entry);
+			}
+		}
+
+		return overrides;
+	}
+
+	/**
+	 * Gets the value of an item, using the configured override if one is set for it,
+	 * otherwise falling back to the current price type (GE or HA).
+	 */
+	private int getItemValue(int itemId)
+	{
+		if (!itemValueOverrides.isEmpty())
+		{
+			final int override = getCustomPrice(itemManager.getItemComposition(itemId).getMembersName());
+			if (override >= 0)
+			{
+				return override;
+			}
+		}
+
+		return config.priceType() == LootTrackerPriceType.GRAND_EXCHANGE
+			? itemManager.getItemPrice(itemId)
+			: itemManager.getItemComposition(itemId).getHaPrice();
+	}
+
 	private LootTrackerItem buildLootTrackerItem(int itemId, int quantity)
 	{
 		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 		final int gePrice = itemManager.getItemPrice(itemId);
 		final int haPrice = itemComposition.getHaPrice();
 		final boolean ignored = ignoredItems.contains(itemComposition.getMembersName());
+		final int customPrice = getCustomPrice(itemComposition.getMembersName());
 
 		return new LootTrackerItem(
 			itemId,
@@ -1677,6 +1764,7 @@ public class LootTrackerPlugin extends Plugin
 			quantity,
 			gePrice,
 			haPrice,
+			customPrice,
 			ignored);
 	}
 
@@ -1727,9 +1815,7 @@ public class LootTrackerPlugin extends Plugin
 	private void lootReceivedChatMessage(final Collection<ItemStack> items, final String name)
 	{
 		long totalPrice = items.stream()
-			.mapToLong(item -> config.priceType() == LootTrackerPriceType.GRAND_EXCHANGE ?
-				(long) itemManager.getItemPrice(item.getId()) * item.getQuantity() :
-				(long) itemManager.getItemComposition(item.getId()).getHaPrice() * item.getQuantity())
+			.mapToLong(item -> (long) getItemValue(item.getId()) * item.getQuantity())
 			.sum();
 
 		final String message = new ChatMessageBuilder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerRecord.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerRecord.java
@@ -83,6 +83,7 @@ class LootTrackerRecord
 						qty,
 						r.getGePrice(),
 						r.getHaPrice(),
+						item.getCustomPrice(),
 						r.isIgnored()
 					);
 					continue outer;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
+import javax.swing.SwingUtilities;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -685,5 +687,64 @@ public class LootTrackerPluginTest
 		lootTrackerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.INV, itemContainer));
 
 		verify(lootTrackerPlugin).addLoot("Large salvage", -1, LootRecordType.EVENT, null, Collections.singletonList(new ItemStack(ItemID.NAILS, 4)));
+	}
+
+	// LootTrackerPlugin#startUp() constructs the real LootTrackerPanel, which asserts it is
+	// running on the EDT, so it must be invoked from there rather than the test thread.
+	private void startUpOnEdt() throws Exception
+	{
+		try
+		{
+			SwingUtilities.invokeAndWait(() ->
+			{
+				try
+				{
+					lootTrackerPlugin.startUp();
+				}
+				catch (Exception e)
+				{
+					throw new RuntimeException(e);
+				}
+			});
+		}
+		catch (InvocationTargetException e)
+		{
+			throw new RuntimeException(e.getCause());
+		}
+	}
+
+	@Test
+	public void testItemValueOverrideParsing() throws Exception
+	{
+		when(lootTrackerConfig.getIgnoredItems()).thenReturn("");
+		when(lootTrackerConfig.getIgnoredEvents()).thenReturn("");
+		when(lootTrackerConfig.getItemValueOverrides()).thenReturn(
+			"Elder venator fang:120000000, Crystal shard : 13000 ,Duplicate item:100,Duplicate item:200,Foo: Bar:50");
+
+		startUpOnEdt();
+
+		assertEquals(120000000, lootTrackerPlugin.getCustomPrice("Elder venator fang"));
+		assertEquals(13000, lootTrackerPlugin.getCustomPrice("Crystal shard"));
+		// later entries win when the same name is repeated
+		assertEquals(200, lootTrackerPlugin.getCustomPrice("Duplicate item"));
+		// only the last colon in an entry is treated as the name/value separator
+		assertEquals(50, lootTrackerPlugin.getCustomPrice("Foo: Bar"));
+		// items with no configured override fall back to -1
+		assertEquals(-1, lootTrackerPlugin.getCustomPrice("Unconfigured item"));
+	}
+
+	@Test
+	public void testItemValueOverrideParsingIgnoresMalformedEntries() throws Exception
+	{
+		when(lootTrackerConfig.getIgnoredItems()).thenReturn("");
+		when(lootTrackerConfig.getIgnoredEvents()).thenReturn("");
+		when(lootTrackerConfig.getItemValueOverrides()).thenReturn(
+			"no colon here,:100,Not a number:abc,Valid item:500");
+
+		startUpOnEdt();
+
+		assertEquals(-1, lootTrackerPlugin.getCustomPrice("no colon here"));
+		assertEquals(-1, lootTrackerPlugin.getCustomPrice("Not a number"));
+		assertEquals(500, lootTrackerPlugin.getCustomPrice("Valid item"));
 	}
 }


### PR DESCRIPTION
## Summary

Adds a per-item **custom value override** to the Loot Tracker, mainly for untradeable items whose GE/HA price isn't accurate (or is 0). The override replaces both the GE and HA price shown for that item in the tracker UI, box totals, tooltips, and kill/raid chat messages — regardless of which price type (GE/HA) is currently selected.

## How it works

- **Right-click any item** in the Loot Tracker → **Set custom value** (or **Edit**/**Clear** if one's already set). A dialog prompts for a gp value; leaving it blank clears the override.

<img width="304" height="426" alt="EE555F7A-4087-4455-B8C8-D6B7F2F0BA24" src="https://github.com/user-attachments/assets/9db269db-070a-47fe-b12c-475d83d1d342" />

- **Bulk edit**: right-click the totals bar at the bottom of the panel → **Edit custom values...** opens a multi-line editor (`itemName:value`, one per line) for reviewing/importing/exporting the whole list at once. Invalid lines (bad format, negative values, commas) are rejected up front with a clear error instead of being silently dropped, and clearing the whole list requires confirmation.

<img width="324" height="538" alt="A362E3B4-A811-4867-940D-A6D0904EBDA1" src="https://github.com/user-attachments/assets/c9bfcee6-f9f7-4b07-bb2c-b0d80b9b944d" />

- Values are stored in a single config string, matching the existing `ignoredItems`/`ignoredEvents` pattern in this plugin.


## Testing

- Added unit tests covering the config-string parser (valid entries, duplicate names, whitespace, colon-in-name, and malformed input).
- Manually verified in-client: setting/editing/clearing via right-click, bulk edit with valid and invalid input, GE/HA price-type toggle still respects the override, and totals/tooltips update correctly.

## Known limitations

- **Item names must match exactly.** Lookup is a case-sensitive exact match against the item's display name, with no fuzzy matching or autocomplete when typing in the bulk editor. A typo (or a future in-game rename of that item) means the override silently stops applying — it falls back to GE/HA price with no warning that anything changed.
- **One value applies to both GE and HA.** By design, the override replaces both price types uniformly rather than letting you set a different value per price type for the same item.
- **The raw config field is intentionally hidden from Settings**, unlike this plugin's existing `ignoredItems`/`ignoredEvents` fields which stay visible there. The right-click and bulk-edit dialogs are the only way to view/manage the list — there's no Settings-page fallback. This was a deliberate tradeoff (the bulk dialog gives structured editing + validation that a raw text field wouldn't), but it's a departure from this plugin's established pattern and open to reconsideration.
- **In-memory override state isn't synchronized** across the config-change thread and the game/client thread (a plain, non-`volatile` map). This mirrors the pre-existing behavior of `ignoredItems`/`ignoredEvents` in this same plugin, not a new risk introduced here, but it means a just-set override could theoretically be missed for a loot event processed in the same instant.
- **Scoped to the Loot Tracker only.** The override map lives entirely inside this plugin's own state and isn't visible to anything else — bank totals, item hover tooltips, the GE search panel, inventory value overlays, etc. all still price the item at its real GE/HA value. Sharing the override more broadly would mean lifting it out of `LootTrackerPlugin` into a core service (most naturally `ItemManager`, since almost everything already calls through it for GE price), which is a much bigger, more invasive change than this PR's scope — out of scope here, but worth calling out as a natural follow-up if there's appetite for it.
