### PR TITLE
idle notifier: add bloodwood sap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -200,6 +200,8 @@ public class IdleNotifierPlugin extends Plugin
 			case AnimationID.HUMAN_CANOEING_CARVE_CRYSTAL_2H_AXE_INACTIVE:
 			case AnimationID.HUMAN_CANOEING_CARVE_3A_2H_AXE:
 			case AnimationID.TBW_CLEANUP_PLAYER_SURPRISE_STEPBACK:
+			/* Sap collection */
+			case AnimationID.HUMAN_PICKUPTABLE_WALKMERGE_NOHELD:
 			/* Firemaking */
 			case AnimationID.FORESTRY_CAMPFIRE_BURNING_ARCTIC_PINE_LOG:
 			case AnimationID.FORESTRY_CAMPFIRE_BURNING_BLISTERWOOD_LOGS:


### PR DESCRIPTION
The animation that collecting the sap of the bloodwood tree is 11091. 

The graphic is also -1, I worry that 11091 will be fired by other things and then people would get the idle notification when they used to not to for it.

<img width="1358" height="450" alt="image" src="https://github.com/user-attachments/assets/9d5d8645-290d-4aa8-804b-684771fb455e" />
