### PR TITLE
gpu: read screenshot pixels directly into image buffer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -35,7 +35,6 @@ import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.util.HashMap;
 import java.util.Map;
@@ -1537,26 +1536,19 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		width = getScaledValue(t.getScaleX(), width);
 		height = getScaledValue(t.getScaleY(), height);
 
-		ByteBuffer buffer = ByteBuffer.allocateDirect(width * height * 4)
-			.order(ByteOrder.nativeOrder());
-
-		glReadBuffer(awtContext.getBufferMode());
-		glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
-
 		BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
 		int[] pixels = ((DataBufferInt) image.getRaster().getDataBuffer()).getData();
 
-		for (int y = 0; y < height; ++y)
-		{
-			for (int x = 0; x < width; ++x)
-			{
-				int r = buffer.get() & 0xff;
-				int g = buffer.get() & 0xff;
-				int b = buffer.get() & 0xff;
-				buffer.get(); // alpha
+		glReadBuffer(awtContext.getBufferMode());
+		glReadPixels(0, 0, width, height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, pixels);
 
-				pixels[(height - y - 1) * width + x] = (r << 16) | (g << 8) | b;
-			}
+		// glReadPixels returns rows bottom-up, flip them to top-down
+		int[] row = new int[width];
+		for (int y0 = 0, y1 = height - 1; y0 < y1; ++y0, --y1)
+		{
+			System.arraycopy(pixels, y0 * width, row, 0, width);
+			System.arraycopy(pixels, y1 * width, pixels, y0 * width, width);
+			System.arraycopy(row, 0, pixels, y1 * width, width);
 		}
 
 		return image;


### PR DESCRIPTION
Never really contributed to the client itself, so forgive me if I'm mis-stepping here... Looking into the GPU integration and the way screenshots work due to the fact we're lacking the ability to get lwgjl-leveraging plugin approval at the moment, and noticed a minor perf increase we could get cheap.

screenshot() currently reads the framebuffer as RGBA bytes into a freshly allocated direct ByteBuffer, then reassembles every pixel with four relative ByteBuffer.get() calls in a nested loop. For a w×h capture that's a 4*w*h native allocation plus ~4*w*h bounds-checked byte reads per screenshot, all on the render thread.

This reads the pixels with GL_BGRA / GL_UNSIGNED_INT_8_8_8_8_REV directly into the BufferedImage's backing int[] instead, then flips the rows in place with System.arraycopy. The packed-int format matches TYPE_INT_RGB's layout, and being a packed type its component order is defined relative to the int, so it's endian-independent. GL_BGRA + _REV is also the readback format drivers commonly service without a conversion pass. Both are core since OpenGL 1.2.

One behavioral note: the high byte of each pixel now carries the framebuffer's alpha instead of always being 0. TYPE_INT_RGB's color model has no alpha mask, so it's ignored by rendering, getRGB(), and image encoders alike.

No API change; output images are identical. Mostly motivated by requestNextFrameListener consumers that capture more than a single frame, where this path currently dominates.