### PR TITLE
client: add continuous frame listener to DrawManager

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -35,6 +35,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferInt;
 import java.awt.image.VolatileImage;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -121,6 +122,7 @@ public class Hooks implements Callbacks
 	private Dimension lastStretchedDimensions;
 	private VolatileImage stretchedImage;
 	private Graphics2D stretchedGraphics;
+	private BufferedImage frameStaging;
 
 	private long lastCheck;
 	private boolean shouldProcessGameTick;
@@ -479,6 +481,52 @@ public class Hooks implements Callbacks
 		// finalImage is backed by the client buffer which will change soon. make a copy
 		// so that callbacks can safely use it later from threads.
 		drawManager.processDrawComplete(() -> screenshot(finalImage));
+
+		if (drawManager.hasFrameListeners())
+		{
+			processFrame(finalImage);
+		}
+		else
+		{
+			frameStaging = null;
+		}
+	}
+
+	private void processFrame(Image src)
+	{
+		if (src instanceof BufferedImage)
+		{
+			// unstretched, this is the int-backed client buffer, which is stable
+			// for the duration of the synchronous listener callback
+			final BufferedImage bufferedImage = (BufferedImage) src;
+			if (bufferedImage.getRaster().getDataBuffer() instanceof DataBufferInt)
+			{
+				frameStaging = null;
+				drawManager.processFrame(((DataBufferInt) bufferedImage.getRaster().getDataBuffer()).getData(),
+					bufferedImage.getWidth(), bufferedImage.getHeight());
+				return;
+			}
+		}
+
+		// stretched, the frame is a VolatileImage with no direct pixel access;
+		// blit it into a reused staging image
+		final AffineTransform transform = clientUi.getGraphicsConfiguration().getDefaultTransform();
+		int swidth = src.getWidth(null);
+		int sheight = src.getHeight(null);
+		int twidth = (int) (swidth * transform.getScaleX() + .5);
+		int theight = (int) (sheight * transform.getScaleY() + .5);
+
+		if (frameStaging == null || frameStaging.getWidth() != twidth || frameStaging.getHeight() != theight)
+		{
+			frameStaging = new BufferedImage(twidth, theight, BufferedImage.TYPE_INT_RGB);
+		}
+
+		Graphics2D graphics = (Graphics2D) frameStaging.getGraphics();
+		graphics.setTransform(transform);
+		graphics.drawImage(src, 0, 0, swidth, sheight, null);
+		graphics.dispose();
+
+		drawManager.processFrame(((DataBufferInt) frameStaging.getRaster().getDataBuffer()).getData(), twidth, theight);
 	}
 
 	private Image screenshot(Image src)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -36,6 +36,7 @@ import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -153,6 +154,14 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 	private int interfaceTexture;
 	private int interfacePbo;
+
+	private static final int FRAME_PBO_COUNT = 3;
+	private final int[] framePbos = new int[FRAME_PBO_COUNT];
+	private final long[] framePboFences = new long[FRAME_PBO_COUNT];
+	private int framePboIndex;
+	private int framePboWidth;
+	private int framePboHeight;
+	private int[] framePixels;
 
 	private int vaoUiHandle;
 	private int vboUiHandle;
@@ -461,6 +470,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 				root.free();
 
 				shutdownInterfaceTexture();
+				shutdownFramePbos();
 				shutdownProgram();
 				shutdownVao();
 				shutdownBuffers();
@@ -769,6 +779,45 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		glDeleteBuffers(interfacePbo);
 		glDeleteTextures(interfaceTexture);
 		interfaceTexture = -1;
+	}
+
+	private void initFramePbos(int width, int height)
+	{
+		shutdownFramePbos();
+
+		for (int i = 0; i < FRAME_PBO_COUNT; ++i)
+		{
+			framePbos[i] = glGenBuffers();
+			glBindBuffer(GL_PIXEL_PACK_BUFFER, framePbos[i]);
+			glBufferData(GL_PIXEL_PACK_BUFFER, (long) width * height * Integer.BYTES, GL_STREAM_READ);
+		}
+		glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+		framePboWidth = width;
+		framePboHeight = height;
+		framePixels = new int[width * height];
+	}
+
+	private void shutdownFramePbos()
+	{
+		for (int i = 0; i < FRAME_PBO_COUNT; ++i)
+		{
+			if (framePbos[i] != 0)
+			{
+				glDeleteBuffers(framePbos[i]);
+				framePbos[i] = 0;
+			}
+			if (framePboFences[i] != 0)
+			{
+				glDeleteSync(framePboFences[i]);
+				framePboFences[i] = 0;
+			}
+		}
+
+		framePboIndex = 0;
+		framePboWidth = 0;
+		framePboHeight = 0;
+		framePixels = null;
 	}
 
 	private void initFbo(int width, int height, int aaSamples)
@@ -1539,6 +1588,15 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 		drawManager.processDrawComplete(this::screenshot);
 
+		if (drawManager.hasFrameListeners())
+		{
+			captureFrame();
+		}
+		else if (framePboWidth != 0)
+		{
+			shutdownFramePbos();
+		}
+
 		glBindFramebuffer(GL_FRAMEBUFFER, awtContext.getFramebuffer(false));
 
 		checkGLErrors();
@@ -1598,11 +1656,9 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	}
 
 	/**
-	 * Convert the front framebuffer to an Image
-	 *
-	 * @return
+	 * Size of the rendered frame in the front framebuffer
 	 */
-	private Image screenshot()
+	private Dimension frameSize()
 	{
 		int width = client.getCanvasWidth();
 		int height = client.getCanvasHeight();
@@ -1616,8 +1672,19 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 		final GraphicsConfiguration graphicsConfiguration = clientUI.getGraphicsConfiguration();
 		final AffineTransform t = graphicsConfiguration.getDefaultTransform();
-		width = getScaledValue(t.getScaleX(), width);
-		height = getScaledValue(t.getScaleY(), height);
+		return new Dimension(getScaledValue(t.getScaleX(), width), getScaledValue(t.getScaleY(), height));
+	}
+
+	/**
+	 * Convert the front framebuffer to an Image
+	 *
+	 * @return
+	 */
+	private Image screenshot()
+	{
+		Dimension frameSize = frameSize();
+		int width = frameSize.width;
+		int height = frameSize.height;
 
 		BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
 		int[] pixels = ((DataBufferInt) image.getRaster().getDataBuffer()).getData();
@@ -1635,6 +1702,70 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		}
 
 		return image;
+	}
+
+	/**
+	 * Asynchronously read the front framebuffer back through a ring of PBOs and
+	 * deliver completed readbacks to frame listeners. Each call maps the buffer
+	 * enqueued FRAME_PBO_COUNT frames earlier, so delivery does not stall on the
+	 * GPU, at the cost of a few frames of latency.
+	 */
+	private void captureFrame()
+	{
+		Dimension frameSize = frameSize();
+		final int width = frameSize.width;
+		final int height = frameSize.height;
+		if (width <= 0 || height <= 0)
+		{
+			return;
+		}
+
+		if (width != framePboWidth || height != framePboHeight)
+		{
+			initFramePbos(width, height);
+		}
+
+		final int idx = framePboIndex;
+		framePboIndex = (framePboIndex + 1) % FRAME_PBO_COUNT;
+
+		// deliver the oldest pending readback before reusing its buffer
+		if (framePboFences[idx] != 0)
+		{
+			int status = glClientWaitSync(framePboFences[idx], GL_SYNC_FLUSH_COMMANDS_BIT, 0);
+			glDeleteSync(framePboFences[idx]);
+			framePboFences[idx] = 0;
+
+			// if the GPU still isn't done FRAME_PBO_COUNT frames later, drop the frame instead of stalling
+			if (status == GL_ALREADY_SIGNALED || status == GL_CONDITION_SATISFIED)
+			{
+				glBindBuffer(GL_PIXEL_PACK_BUFFER, framePbos[idx]);
+				ByteBuffer mapped = glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
+				if (mapped != null)
+				{
+					// rows are bottom-up, flip while copying out
+					IntBuffer buf = mapped.asIntBuffer();
+					for (int y = 0; y < height; ++y)
+					{
+						buf.position((height - y - 1) * width);
+						buf.get(framePixels, y * width, width);
+					}
+					glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+					glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+					drawManager.processFrame(framePixels, width, height);
+				}
+				else
+				{
+					glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+				}
+			}
+		}
+
+		glBindBuffer(GL_PIXEL_PACK_BUFFER, framePbos[idx]);
+		glReadBuffer(awtContext.getBufferMode());
+		glReadPixels(0, 0, width, height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, 0L);
+		glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+		framePboFences[idx] = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/ui/DrawManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/DrawManager.java
@@ -38,8 +38,27 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DrawManager
 {
+	/**
+	 * A listener which receives the pixels of every rendered frame.
+	 */
+	public interface FrameListener
+	{
+		/**
+		 * Called with the pixels of a rendered frame. Pixels are packed 32-bit
+		 * 0xAARRGGBB, row-major, top-down; the contents of the alpha channel are
+		 * undefined. The array is reused between frames and may be the renderer's
+		 * live buffer: it is only valid until this method returns and must not be
+		 * modified; copy it if it is needed later. This is called on the render
+		 * thread, so must return quickly. Depending on the renderer, frames may
+		 * be delivered a few frames after they are drawn, and frames may be
+		 * skipped if the readback is not complete in time.
+		 */
+		void onFrame(int[] pixels, int width, int height);
+	}
+
 	private final List<Runnable> everyFrame = new CopyOnWriteArrayList<>();
 	private final Queue<Consumer<Image>> nextFrame = new ConcurrentLinkedQueue<>();
+	private final List<FrameListener> frameListeners = new CopyOnWriteArrayList<>();
 
 	public void registerEveryFrameListener(Runnable everyFrameListener)
 	{
@@ -57,6 +76,48 @@ public class DrawManager
 	public void requestNextFrameListener(Consumer<Image> nextFrameListener)
 	{
 		nextFrame.add(nextFrameListener);
+	}
+
+	public void registerFrameListener(FrameListener frameListener)
+	{
+		if (!frameListeners.contains(frameListener))
+		{
+			frameListeners.add(frameListener);
+		}
+	}
+
+	public void unregisterFrameListener(FrameListener frameListener)
+	{
+		frameListeners.remove(frameListener);
+	}
+
+	/**
+	 * Whether any frame listeners are registered. Renderers may use this to
+	 * skip frame readback entirely when nothing is listening.
+	 */
+	public boolean hasFrameListeners()
+	{
+		return !frameListeners.isEmpty();
+	}
+
+	/**
+	 * Deliver a frame to registered frame listeners. Called by the renderer.
+	 *
+	 * @see FrameListener#onFrame(int[], int, int)
+	 */
+	public void processFrame(int[] pixels, int width, int height)
+	{
+		for (FrameListener frameListener : frameListeners)
+		{
+			try
+			{
+				frameListener.onFrame(pixels, width, height);
+			}
+			catch (Exception e)
+			{
+				log.error("Error in frame listener", e);
+			}
+		}
 	}
 
 	public void processDrawComplete(Supplier<Image> imageSupplier)


### PR DESCRIPTION
Adds DrawManager.FrameListener, a registration-based listener which receives the pixels of every rendered frame as a packed ARGB int[]

requestNextFrameListener as it stands is designed for one-off screenshots; video-capture type plugins (video/clip recorders) have no better option than re-requesting it every frame. [#20312](https://github.com/runelite/runelite/pull/20312) removed most of the CPU-side conversion cost of that path, but what remains is inherent to its design: a synchronous glReadPixels that stalls the pipeline, and a full BufferedImage allocation, per captured frame. Plugins also can't currently ship their own GL readback code on the hub due to maintainer constraints.

The GPU plugin services frame listeners through a ring of 3 pixel pack buffers with fence syncs: readbacks are enqueued after buffer swap and mapped once the ring wraps (~3 frames later), so the render thread never blocks on the GPU. If a fence still isn't signaled when its buffer comes up for reuse, the frame is dropped rather than waited on. Pixels are delivered into a single reused int[], so there is no per-frame allocation. The buffers are torn down when the last listener unregisters and on plugin shutdown, and reallocated on canvas resize; when no listener is registered the cost is one branch per frame. The software renderer delivers frames from the image it already has in hand via a reused staging image.

Delivery contract: packed 32-bit ARGB, row-major top-down, alpha undefined; the array is only valid for the duration of the callback; called on the render thread; delivery is delayed by the ring depth and frames may be skipped rather than stalled on.

A small comparison using 10-second continuous-capture phases (consumer copies each frame), GPU plugin at 1440p on an RTX 3080, at a 60fps vsync cap with frame times measured swap-to-swap on the render thread:
| phase | avg FPS | median | p99 | max | frames captured |
| -- | -- | -- | -- | -- | -- |
| baseline (no capture) | 60.0 | 16.71 ms | 19.26 ms | 30.40 ms | — |
| requestNextFrameListener per frame (current method of stitching video together) | 50.2 (−16%) | 18.89 ms | 30.21 ms | 33.53 ms | 502 |
| frame listener (this PR) | 60.1 | 16.77 ms | 18.49 ms | 19.14 ms | 601 (0 dropped) |

Plugin-facing API mirrors the current registerEveryFrameListener pattern, so hub developers can leverage the frame listener without needing to extend their own GL code:
```java
@Inject
private DrawManager drawManager;

private final DrawManager.FrameListener listener = (pixels, width, height) ->
{
	// packed ARGB, top-down; array is reused — copy what you keep
};

// start capturing
drawManager.registerFrameListener(listener);

// stop; readback stops and PBOs are freed when the last listener leaves
drawManager.unregisterFrameListener(listener);```
