### PR TITLE
chat: Move global press-to-chat handling from "Key Remapping" to a default runelite feature

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -59,6 +59,13 @@ public interface RuneLiteConfig extends Config
 	)
 	String overlaySettings = "overlaySettings";
 
+	@ConfigSection(
+		name = "Chat settings",
+		description = "Settings relating to chat input.",
+		position = 3
+	)
+	String chatSettings = "chatSettings";
+
 	@ConfigItem(
 		keyName = "gameSize",
 		name = "Game size",
@@ -445,6 +452,30 @@ public interface RuneLiteConfig extends Config
 	default Keybind panelToggleKey()
 	{
 		return new Keybind(KeyEvent.VK_F12, InputEvent.CTRL_DOWN_MASK);
+	}
+
+	@ConfigItem(
+		keyName = "pressEnterToChat",
+		name = "Press key to chat",
+		description = "Locks the chatbox until the chat key is pressed, allowing letter hotkeys to be used outside of chat.",
+		position = 47,
+		section = chatSettings
+	)
+	default boolean pressEnterToChat()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "chatActivationKey",
+		name = "Chat key",
+		description = "The key used to activate chat while press key to chat is enabled.",
+		position = 48,
+		section = chatSettings
+	)
+	default ModifierlessKeybind chatActivationKey()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_ENTER, 0);
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxTextInput.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxTextInput.java
@@ -607,6 +607,12 @@ public class ChatboxTextInput extends ChatboxInput implements KeyListener, Mouse
 	}
 
 	@Override
+	public boolean isEnabledOnChatInput()
+	{
+		return true;
+	}
+
+	@Override
 	public void keyTyped(KeyEvent e)
 	{
 		if (!chatboxPanelManager.shouldTakeInput())

--- a/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxTextMenuInput.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxTextMenuInput.java
@@ -174,6 +174,11 @@ public class ChatboxTextMenuInput extends ChatboxInput implements KeyListener
 		}
 	}
 
+	@Override
+	public boolean isEnabledOnChatInput()
+	{
+		return true;
+	}
 
 	@Override
 	public void keyTyped(KeyEvent e)

--- a/runelite-client/src/main/java/net/runelite/client/input/ChatboxInputManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/input/ChatboxInputManager.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Abexlry <abexlry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.input;
+
+import com.google.common.base.Strings;
+import java.awt.Color;
+import java.awt.event.KeyEvent;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.ScriptCallbackEvent;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.gameval.VarClientID;
+import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.RuneLiteConfig;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.ui.JagexColors;
+import net.runelite.client.util.ColorUtil;
+
+@Singleton
+public class ChatboxInputManager
+{
+	private final Client client;
+	private final ClientThread clientThread;
+	private final RuneLiteConfig config;
+
+	private boolean keyRemappingPluginEnabled;
+	private char blockedChar = KeyEvent.CHAR_UNDEFINED;
+
+	@Getter
+	private boolean typing;
+
+	@Inject
+	private ChatboxInputManager(Client client, ClientThread clientThread, RuneLiteConfig config, EventBus eventBus)
+	{
+		this.client = client;
+		this.clientThread = clientThread;
+		this.config = config;
+		eventBus.register(this);
+	}
+
+	public void setKeyRemappingPluginEnabled(boolean keyRemappingPluginEnabled)
+	{
+		if (this.keyRemappingPluginEnabled == keyRemappingPluginEnabled)
+		{
+			return;
+		}
+
+		boolean wasEnabled = isEnabled();
+		this.keyRemappingPluginEnabled = keyRemappingPluginEnabled;
+		if (wasEnabled != isEnabled())
+		{
+			clientThread.invoke(this::updateChatLock);
+		}
+	}
+
+	private boolean isEnabled()
+	{
+		return config.pressEnterToChat() || keyRemappingPluginEnabled;
+	}
+
+	public boolean isChatInputActive()
+	{
+		return isEnabled() && typing && chatboxFocused();
+	}
+
+	public void processKeyTyped(KeyEvent e)
+	{
+		if (e.getKeyChar() == blockedChar)
+		{
+			blockedChar = KeyEvent.CHAR_UNDEFINED;
+			e.consume();
+		}
+	}
+
+	public void processKeyPressed(KeyEvent e)
+	{
+		if (!isEnabled() || !chatboxFocused())
+		{
+			return;
+		}
+
+		if (!typing)
+		{
+			if (isChatActivationKey(e))
+			{
+				typing = true;
+				clientThread.invoke(this::unlockChat);
+
+				if (shouldConsumeActivationKey(e))
+				{
+					blockedChar = e.getKeyChar();
+					e.consume();
+				}
+			}
+
+			return;
+		}
+
+		switch (e.getKeyCode())
+		{
+			case KeyEvent.VK_ESCAPE:
+				e.consume();
+				typing = false;
+				clientThread.invoke(() ->
+				{
+					client.setVarcStrValue(VarClientID.CHATINPUT, "");
+					lockChat();
+				});
+				break;
+			case KeyEvent.VK_ENTER:
+				typing = false;
+				clientThread.invoke(this::lockChat);
+				break;
+			case KeyEvent.VK_BACK_SPACE:
+				if (Strings.isNullOrEmpty(client.getVarcStrValue(VarClientID.CHATINPUT)))
+				{
+					typing = false;
+					clientThread.invoke(this::lockChat);
+				}
+				break;
+		}
+	}
+
+	public void processKeyReleased(KeyEvent e)
+	{
+		if (e.getKeyChar() == blockedChar)
+		{
+			blockedChar = KeyEvent.CHAR_UNDEFINED;
+		}
+	}
+
+	private boolean isChatActivationKey(KeyEvent e)
+	{
+		return config.chatActivationKey().matches(e)
+			|| isChatPrefixKey(e);
+	}
+
+	private static boolean shouldConsumeActivationKey(KeyEvent e)
+	{
+		return e.getKeyChar() != KeyEvent.CHAR_UNDEFINED
+			&& !isChatPrefixKey(e);
+	}
+
+	private static boolean isChatPrefixKey(KeyEvent e)
+	{
+		return e.getKeyChar() == '/'
+			|| e.getKeyChar() == ':'
+			|| e.getKeyCode() == KeyEvent.VK_COLON
+			|| e.getKeyCode() == KeyEvent.VK_SEMICOLON && e.isShiftDown();
+	}
+
+	public boolean chatboxFocused()
+	{
+		Widget chatboxParent = client.getWidget(InterfaceID.Chatbox.UNIVERSE);
+		if (chatboxParent == null || chatboxParent.getOnKeyListener() == null)
+		{
+			return false;
+		}
+
+		// If the search box on the world map is open and focused, ~keypress_permit blocks the keypress.
+		Widget worldMapSearch = client.getWidget(InterfaceID.Worldmap.MAPLIST_DISPLAY);
+		if (worldMapSearch != null && client.getVarcIntValue(VarClientID.WORLDMAP_SEARCHING) == 1)
+		{
+			return false;
+		}
+
+		// The report interface blocks input due to 162:54 being hidden, however player/npc dialog and
+		// options do this too, and so we can't disable remapping just due to 162:54 being hidden.
+		Widget report = client.getWidget(InterfaceID.Reportabuse.UNIVERSE);
+		if (report != null)
+		{
+			return false;
+		}
+
+		return client.getFocusedInputFieldWidget() == null;
+	}
+
+	public boolean isDialogOpen()
+	{
+		return isHidden(InterfaceID.Chatbox.MES_LAYER_HIDE) || isHidden(InterfaceID.Chatbox.CHATDISPLAY)
+			|| !isHidden(InterfaceID.BankpinKeypad.UNIVERSE);
+	}
+
+	public boolean isOptionsDialogOpen()
+	{
+		return client.getWidget(InterfaceID.Chatmenu.OPTIONS) != null;
+	}
+
+	private boolean isHidden(int component)
+	{
+		Widget w = client.getWidget(component);
+		return w == null || w.isSelfHidden();
+	}
+
+	@Subscribe
+	public void onScriptCallbackEvent(ScriptCallbackEvent scriptCallbackEvent)
+	{
+		if (!isEnabled())
+		{
+			return;
+		}
+
+		switch (scriptCallbackEvent.getEventName())
+		{
+			case "setChatboxInput":
+				if (!typing)
+				{
+					lockChat();
+				}
+				break;
+			case "blockChatInput":
+				if (!typing)
+				{
+					int[] intStack = client.getIntStack();
+					int intStackSize = client.getIntStackSize();
+					intStack[intStackSize - 1] = 1;
+				}
+				break;
+		}
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged event)
+	{
+		if (event.getGameState() == GameState.LOGGED_IN)
+		{
+			updateChatLock();
+		}
+		else
+		{
+			typing = false;
+			blockedChar = KeyEvent.CHAR_UNDEFINED;
+		}
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (RuneLiteConfig.GROUP_NAME.equals(event.getGroup())
+			&& ("pressEnterToChat".equals(event.getKey()) || "chatActivationKey".equals(event.getKey())))
+		{
+			clientThread.invoke(this::updateChatLock);
+		}
+	}
+
+	private void updateChatLock()
+	{
+		if (client.getGameState() != GameState.LOGGED_IN)
+		{
+			return;
+		}
+
+		typing = false;
+		blockedChar = KeyEvent.CHAR_UNDEFINED;
+		if (isEnabled())
+		{
+			client.setVarcStrValue(VarClientID.CHATINPUT, "");
+			lockChat();
+		}
+		else
+		{
+			unlockChat();
+		}
+	}
+
+	private void lockChat()
+	{
+		setChatboxInput("Press " + config.chatActivationKey() + " to Chat...");
+	}
+
+	private void unlockChat()
+	{
+		if (client.getGameState() == GameState.LOGGED_IN)
+		{
+			final boolean isChatboxTransparent = client.isResized() && client.getVarbitValue(VarbitID.CHATBOX_TRANSPARENCY) == 1;
+			final Color textColor = isChatboxTransparent ? JagexColors.CHAT_TYPED_TEXT_TRANSPARENT_BACKGROUND : JagexColors.CHAT_TYPED_TEXT_OPAQUE_BACKGROUND;
+			setChatboxInput(ColorUtil.wrapWithColorTag(client.getVarcStrValue(VarClientID.CHATINPUT) + "*", textColor));
+		}
+	}
+
+	private void setChatboxInput(String input)
+	{
+		Widget widget = client.getWidget(InterfaceID.Chatbox.INPUT);
+		if (widget == null)
+		{
+			return;
+		}
+
+		String text = widget.getText();
+		int idx = text.indexOf(':');
+		if (idx != -1)
+		{
+			String newText = text.substring(0, idx) + ": " + input;
+			widget.setText(newText);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/input/KeyListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/input/KeyListener.java
@@ -31,6 +31,11 @@ public interface KeyListener extends java.awt.event.KeyListener
 		return false;
 	}
 
+	default boolean isEnabledOnChatInput()
+	{
+		return false;
+	}
+
 	default void focusLost()
 	{
 	}

--- a/runelite-client/src/main/java/net/runelite/client/input/KeyManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/input/KeyManager.java
@@ -42,11 +42,13 @@ import net.runelite.client.eventbus.Subscribe;
 public class KeyManager
 {
 	private final Client client;
+	private final ChatboxInputManager chatboxInputManager;
 
 	@Inject
-	private KeyManager(@Nullable final Client client, final EventBus eventBus)
+	private KeyManager(@Nullable final Client client, final EventBus eventBus, final ChatboxInputManager chatboxInputManager)
 	{
 		this.client = client;
+		this.chatboxInputManager = chatboxInputManager;
 		eventBus.register(this);
 	}
 
@@ -77,9 +79,17 @@ public class KeyManager
 			return;
 		}
 
+		boolean chatInputActive = chatboxInputManager.isChatInputActive();
+		chatboxInputManager.processKeyPressed(keyEvent);
+		chatInputActive |= chatboxInputManager.isChatInputActive();
+		if (keyEvent.isConsumed())
+		{
+			return;
+		}
+
 		for (KeyListener keyListener : keyListeners)
 		{
-			if (!shouldProcess(keyListener))
+			if (!shouldProcess(keyListener, chatInputActive))
 			{
 				continue;
 			}
@@ -102,9 +112,15 @@ public class KeyManager
 			return;
 		}
 
+		chatboxInputManager.processKeyReleased(keyEvent);
+		if (keyEvent.isConsumed())
+		{
+			return;
+		}
+
 		for (KeyListener keyListener : keyListeners)
 		{
-			if (!shouldProcess(keyListener))
+			if (!shouldProcess(keyListener, false))
 			{
 				continue;
 			}
@@ -127,9 +143,17 @@ public class KeyManager
 			return;
 		}
 
+		boolean chatInputActive = chatboxInputManager.isChatInputActive();
+		chatboxInputManager.processKeyTyped(keyEvent);
+		chatInputActive |= chatboxInputManager.isChatInputActive();
+		if (keyEvent.isConsumed())
+		{
+			return;
+		}
+
 		for (KeyListener keyListener : keyListeners)
 		{
-			if (!shouldProcess(keyListener))
+			if (!shouldProcess(keyListener, chatInputActive))
 			{
 				continue;
 			}
@@ -145,7 +169,7 @@ public class KeyManager
 		}
 	}
 
-	private boolean shouldProcess(final KeyListener keyListener)
+	private boolean shouldProcess(final KeyListener keyListener, boolean chatInputActive)
 	{
 		if (client == null)
 		{
@@ -157,6 +181,11 @@ public class KeyManager
 		if (gameState == GameState.LOGIN_SCREEN || gameState == GameState.LOGIN_SCREEN_AUTHENTICATOR)
 		{
 			return keyListener.isEnabledOnLoginScreen();
+		}
+
+		if (chatInputActive)
+		{
+			return keyListener.isEnabledOnChatInput();
 		}
 
 		return true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatKeyboardListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatKeyboardListener.java
@@ -47,6 +47,12 @@ public class ChatKeyboardListener implements KeyListener
 	private ClientThread clientThread;
 
 	@Override
+	public boolean isEnabledOnChatInput()
+	{
+		return true;
+	}
+
+	@Override
 	public void keyTyped(KeyEvent e)
 	{
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
@@ -369,6 +369,12 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 	{
 	}
 
+	@Override
+	public boolean isEnabledOnChatInput()
+	{
+		return true;
+	}
+
 	private String findPreviousFriend()
 	{
 		final String currentTarget = client.getVarcStrValue(VarClientID.FRIENDTOMESSAGE);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -25,31 +25,22 @@
  */
 package net.runelite.client.plugins.keyremapping;
 
-import com.google.common.base.Strings;
 import java.awt.event.KeyEvent;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
-import net.runelite.api.Client;
-import net.runelite.api.gameval.VarClientID;
-import net.runelite.client.callback.ClientThread;
+import net.runelite.client.input.ChatboxInputManager;
 import net.runelite.client.input.KeyListener;
 
 class KeyRemappingListener implements KeyListener
 {
 	@Inject
-	private KeyRemappingPlugin plugin;
+	private ChatboxInputManager chatboxInputManager;
 
 	@Inject
 	private KeyRemappingConfig config;
-
-	@Inject
-	private Client client;
-
-	@Inject
-	private ClientThread clientThread;
 
 	private final Map<Integer, Integer> modified = new HashMap<>();
 	private final Set<Character> blockedChars = new HashSet<>();
@@ -58,7 +49,7 @@ class KeyRemappingListener implements KeyListener
 	public void keyTyped(KeyEvent e)
 	{
 		char keyChar = e.getKeyChar();
-		if (keyChar != KeyEvent.CHAR_UNDEFINED && blockedChars.contains(keyChar) && plugin.chatboxFocused())
+		if (keyChar != KeyEvent.CHAR_UNDEFINED && blockedChars.contains(keyChar) && chatboxInputManager.chatboxFocused())
 		{
 			e.consume();
 		}
@@ -67,160 +58,116 @@ class KeyRemappingListener implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
-		if (!plugin.chatboxFocused())
+		if (!chatboxInputManager.chatboxFocused() || chatboxInputManager.isTyping())
 		{
 			return;
 		}
 
-		if (!plugin.isTyping())
+		int mappedKeyCode = KeyEvent.VK_UNDEFINED;
+
+		if (config.cameraRemap())
 		{
-			int mappedKeyCode = KeyEvent.VK_UNDEFINED;
-
-			if (config.cameraRemap())
+			if (config.up().matches(e))
 			{
-				if (config.up().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_UP;
-				}
-				else if (config.down().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_DOWN;
-				}
-				else if (config.left().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_LEFT;
-				}
-				else if (config.right().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_RIGHT;
-				}
+				mappedKeyCode = KeyEvent.VK_UP;
 			}
-
-			// In addition to the above checks, the F-key remapping shouldn't
-			// activate when dialogs are open which listen for number keys
-			// to select options
-			if (config.fkeyRemap() && !plugin.isDialogOpen())
+			else if (config.down().matches(e))
 			{
-				if (config.f1().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_F1;
-				}
-				else if (config.f2().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_F2;
-				}
-				else if (config.f3().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_F3;
-				}
-				else if (config.f4().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_F4;
-				}
-				else if (config.f5().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_F5;
-				}
-				else if (config.f6().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_F6;
-				}
-				else if (config.f7().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_F7;
-				}
-				else if (config.f8().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_F8;
-				}
-				else if (config.f9().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_F9;
-				}
-				else if (config.f10().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_F10;
-				}
-				else if (config.f11().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_F11;
-				}
-				else if (config.f12().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_F12;
-				}
-				else if (config.esc().matches(e))
-				{
-					mappedKeyCode = KeyEvent.VK_ESCAPE;
-				}
+				mappedKeyCode = KeyEvent.VK_DOWN;
 			}
-
-			// Do not remap to space key when the options dialog is open, since the options dialog never
-			// listens for space, and the remapped key may be one of keys it listens for.
-			if (plugin.isDialogOpen() && !plugin.isOptionsDialogOpen() && config.space().matches(e))
+			else if (config.left().matches(e))
 			{
-				mappedKeyCode = KeyEvent.VK_SPACE;
+				mappedKeyCode = KeyEvent.VK_LEFT;
 			}
-
-			if (!plugin.isOptionsDialogOpen() && config.control().matches(e))
+			else if (config.right().matches(e))
 			{
-				mappedKeyCode = KeyEvent.VK_CONTROL;
+				mappedKeyCode = KeyEvent.VK_RIGHT;
 			}
-
-			if (mappedKeyCode != KeyEvent.VK_UNDEFINED && mappedKeyCode != e.getKeyCode())
-			{
-				final char keyChar = e.getKeyChar();
-				modified.put(e.getKeyCode(), mappedKeyCode);
-				e.setKeyCode(mappedKeyCode);
-				// arrow keys and fkeys do not have a character
-				e.setKeyChar(KeyEvent.CHAR_UNDEFINED);
-				if (keyChar != KeyEvent.CHAR_UNDEFINED)
-				{
-					// If this key event has a valid key char then a key typed event may be received next,
-					// we must block it
-					blockedChars.add(keyChar);
-				}
-			}
-
-			switch (e.getKeyCode())
-			{
-				case KeyEvent.VK_ENTER:
-				case KeyEvent.VK_SLASH:
-				case KeyEvent.VK_COLON:
-					// refocus chatbox
-					plugin.setTyping(true);
-					clientThread.invoke(plugin::unlockChat);
-					break;
-			}
-
 		}
-		else
+
+		// In addition to the above checks, the F-key remapping shouldn't
+		// activate when dialogs are open which listen for number keys
+		// to select options
+		if (config.fkeyRemap() && !chatboxInputManager.isDialogOpen())
 		{
-			switch (e.getKeyCode())
+			if (config.f1().matches(e))
 			{
-				case KeyEvent.VK_ESCAPE:
-					// When exiting typing mode, block the escape key
-					// so that it doesn't trigger the in-game hotkeys
-					e.consume();
-					plugin.setTyping(false);
-					clientThread.invoke(() ->
-					{
-						client.setVarcStrValue(VarClientID.CHATINPUT, "");
-						plugin.lockChat();
-					});
-					break;
-				case KeyEvent.VK_ENTER:
-					plugin.setTyping(false);
-					clientThread.invoke(plugin::lockChat);
-					break;
-				case KeyEvent.VK_BACK_SPACE:
-					// Only lock chat on backspace when the typed text is now empty
-					if (Strings.isNullOrEmpty(client.getVarcStrValue(VarClientID.CHATINPUT)))
-					{
-						plugin.setTyping(false);
-						clientThread.invoke(plugin::lockChat);
-					}
-					break;
+				mappedKeyCode = KeyEvent.VK_F1;
+			}
+			else if (config.f2().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_F2;
+			}
+			else if (config.f3().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_F3;
+			}
+			else if (config.f4().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_F4;
+			}
+			else if (config.f5().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_F5;
+			}
+			else if (config.f6().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_F6;
+			}
+			else if (config.f7().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_F7;
+			}
+			else if (config.f8().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_F8;
+			}
+			else if (config.f9().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_F9;
+			}
+			else if (config.f10().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_F10;
+			}
+			else if (config.f11().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_F11;
+			}
+			else if (config.f12().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_F12;
+			}
+			else if (config.esc().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_ESCAPE;
+			}
+		}
+
+		// Do not remap to space key when the options dialog is open, since the options dialog never
+		// listens for space, and the remapped key may be one of keys it listens for.
+		if (chatboxInputManager.isDialogOpen() && !chatboxInputManager.isOptionsDialogOpen() && config.space().matches(e))
+		{
+			mappedKeyCode = KeyEvent.VK_SPACE;
+		}
+
+		if (!chatboxInputManager.isOptionsDialogOpen() && config.control().matches(e))
+		{
+			mappedKeyCode = KeyEvent.VK_CONTROL;
+		}
+
+		if (mappedKeyCode != KeyEvent.VK_UNDEFINED && mappedKeyCode != e.getKeyCode())
+		{
+			final char keyChar = e.getKeyChar();
+			modified.put(e.getKeyCode(), mappedKeyCode);
+			e.setKeyCode(mappedKeyCode);
+			// arrow keys and fkeys do not have a character
+			e.setKeyChar(KeyEvent.CHAR_UNDEFINED);
+			if (keyChar != KeyEvent.CHAR_UNDEFINED)
+			{
+				// If this key event has a valid key char then a key typed event may be received next,
+				// we must block it
+				blockedChars.add(keyChar);
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
@@ -26,81 +26,41 @@
 package net.runelite.client.plugins.keyremapping;
 
 import com.google.inject.Provides;
-import java.awt.Color;
 import javax.inject.Inject;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.Setter;
-import net.runelite.api.Client;
-import net.runelite.api.GameState;
-import net.runelite.api.events.ScriptCallbackEvent;
-import net.runelite.api.gameval.InterfaceID;
-import net.runelite.api.gameval.VarClientID;
-import net.runelite.api.gameval.VarbitID;
-import net.runelite.api.widgets.Widget;
-import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.input.ChatboxInputManager;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.ui.JagexColors;
-import net.runelite.client.util.ColorUtil;
 
 @PluginDescriptor(
 	name = "Key Remapping",
-	description = "Allows use of WASD keys for camera movement with 'Press Enter to Chat', and remapping number keys to F-keys",
+	description = "Allows use of WASD keys for camera movement with press-to-chat, and remapping number keys to F-keys",
 	tags = {"enter", "chat", "wasd", "camera"},
 	enabledByDefault = false
 )
 public class KeyRemappingPlugin extends Plugin
 {
-	private static final String PRESS_ENTER_TO_CHAT = "Press Enter to Chat...";
-
-	@Inject
-	private Client client;
-
-	@Inject
-	private ClientThread clientThread;
-
 	@Inject
 	private KeyManager keyManager;
 
 	@Inject
 	private KeyRemappingListener inputListener;
 
-	@Getter(AccessLevel.PACKAGE)
-	@Setter(AccessLevel.PACKAGE)
-	private boolean typing;
+	@Inject
+	private ChatboxInputManager chatboxInputManager;
 
 	@Override
 	protected void startUp() throws Exception
 	{
-		typing = false;
 		keyManager.registerKeyListener(inputListener);
-
-		clientThread.invoke(() ->
-		{
-			if (client.getGameState() == GameState.LOGGED_IN)
-			{
-				lockChat();
-				// Clear any typed text
-				client.setVarcStrValue(VarClientID.CHATINPUT, "");
-			}
-		});
+		chatboxInputManager.setKeyRemappingPluginEnabled(true);
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
-		clientThread.invoke(() ->
-		{
-			if (client.getGameState() == GameState.LOGGED_IN)
-			{
-				unlockChat();
-			}
-		});
-
+		chatboxInputManager.setKeyRemappingPluginEnabled(false);
 		keyManager.unregisterKeyListener(inputListener);
 	}
 
@@ -108,125 +68,5 @@ public class KeyRemappingPlugin extends Plugin
 	KeyRemappingConfig getConfig(ConfigManager configManager)
 	{
 		return configManager.getConfig(KeyRemappingConfig.class);
-	}
-
-	/**
-	 * Check if something other than the chatbox is accepting key input.
-	 * @return
-	 */
-	boolean chatboxFocused()
-	{
-		Widget chatboxParent = client.getWidget(InterfaceID.Chatbox.UNIVERSE);
-		if (chatboxParent == null || chatboxParent.getOnKeyListener() == null)
-		{
-			return false;
-		}
-
-		// If the search box on the world map is open and focused, ~keypress_permit blocks the keypress
-		Widget worldMapSearch = client.getWidget(InterfaceID.Worldmap.MAPLIST_DISPLAY);
-		if (worldMapSearch != null && client.getVarcIntValue(VarClientID.WORLDMAP_SEARCHING) == 1)
-		{
-			return false;
-		}
-
-		// The report interface blocks input due to 162:54 being hidden, however player/npc dialog and
-		// options do this too, and so we can't disable remapping just due to 162:54 being hidden.
-		Widget report = client.getWidget(InterfaceID.Reportabuse.UNIVERSE);
-		if (report != null)
-		{
-			return false;
-		}
-
-		if (client.getFocusedInputFieldWidget() != null)
-		{
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Check if a dialog is open that will grab numerical input, to prevent F-key remapping
-	 * from triggering.
-	 *
-	 * @return
-	 */
-	boolean isDialogOpen()
-	{
-		// Most chat dialogs with numerical input are added without the chatbox or its key listener being removed,
-		// so chatboxFocused() is true. The chatbox onkey script uses the following logic to ignore key presses,
-		// so we will use it too to not remap F-keys.
-		return isHidden(InterfaceID.Chatbox.MES_LAYER_HIDE) || isHidden(InterfaceID.Chatbox.CHATDISPLAY)
-			// We want to block F-key remapping in the bank pin interface too, so it does not interfere with the
-			// Keyboard Bankpin feature of the Bank plugin
-			|| !isHidden(InterfaceID.BankpinKeypad.UNIVERSE);
-	}
-
-	boolean isOptionsDialogOpen()
-	{
-		return client.getWidget(InterfaceID.Chatmenu.OPTIONS) != null;
-	}
-
-	private boolean isHidden(int component)
-	{
-		Widget w = client.getWidget(component);
-		return w == null || w.isSelfHidden();
-	}
-
-	@Subscribe
-	public void onScriptCallbackEvent(ScriptCallbackEvent scriptCallbackEvent)
-	{
-		switch (scriptCallbackEvent.getEventName())
-		{
-			case "setChatboxInput":
-				Widget chatboxInput = client.getWidget(InterfaceID.Chatbox.INPUT);
-				if (chatboxInput != null && !typing)
-				{
-					setChatboxWidgetInput(chatboxInput, PRESS_ENTER_TO_CHAT);
-				}
-				break;
-			case "blockChatInput":
-				if (!typing)
-				{
-					int[] intStack = client.getIntStack();
-					int intStackSize = client.getIntStackSize();
-					intStack[intStackSize - 1] = 1;
-				}
-				break;
-		}
-	}
-
-	void lockChat()
-	{
-		Widget chatboxInput = client.getWidget(InterfaceID.Chatbox.INPUT);
-		if (chatboxInput != null)
-		{
-			setChatboxWidgetInput(chatboxInput, PRESS_ENTER_TO_CHAT);
-		}
-	}
-
-	void unlockChat()
-	{
-		Widget chatboxInput = client.getWidget(InterfaceID.Chatbox.INPUT);
-		if (chatboxInput != null)
-		{
-			if (client.getGameState() == GameState.LOGGED_IN)
-			{
-				final boolean isChatboxTransparent = client.isResized() && client.getVarbitValue(VarbitID.CHATBOX_TRANSPARENCY) == 1;
-				final Color textColor = isChatboxTransparent ? JagexColors.CHAT_TYPED_TEXT_TRANSPARENT_BACKGROUND : JagexColors.CHAT_TYPED_TEXT_OPAQUE_BACKGROUND;
-				setChatboxWidgetInput(chatboxInput, ColorUtil.wrapWithColorTag(client.getVarcStrValue(VarClientID.CHATINPUT) + "*", textColor));
-			}
-		}
-	}
-
-	private void setChatboxWidgetInput(Widget widget, String input)
-	{
-		String text = widget.getText();
-		int idx = text.indexOf(':');
-		if (idx != -1)
-		{
-			String newText = text.substring(0, idx) + ": " + input;
-			widget.setText(newText);
-		}
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/input/ChatboxInputManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/input/ChatboxInputManagerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026, Endriti
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.input;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.awt.Canvas;
+import java.awt.event.KeyEvent;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ModifierlessKeybind;
+import net.runelite.client.config.RuneLiteConfig;
+import net.runelite.client.eventbus.EventBus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChatboxInputManagerTest
+{
+	@Inject
+	private ChatboxInputManager chatboxInputManager;
+
+	@Mock
+	@Bind
+	private Client client;
+
+	@Mock
+	@Bind
+	private ClientThread clientThread;
+
+	@Mock
+	@Bind
+	private RuneLiteConfig config;
+
+	@Mock
+	@Bind
+	private EventBus eventBus;
+
+	@Mock
+	private Widget chatboxParent;
+
+	@Before
+	public void setUp()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+		when(client.getWidget(InterfaceID.Chatbox.UNIVERSE)).thenReturn(chatboxParent);
+		when(chatboxParent.getOnKeyListener()).thenReturn(new Object[0]);
+		when(config.pressEnterToChat()).thenReturn(true);
+		when(config.chatActivationKey()).thenReturn(new ModifierlessKeybind(KeyEvent.VK_T, 0));
+		doAnswer(invocation ->
+		{
+			Runnable runnable = invocation.getArgument(0);
+			runnable.run();
+			return null;
+		}).when(clientThread).invoke(any(Runnable.class));
+	}
+
+	@Test
+	public void testCustomActivationKeyIsNotTypedIntoChat()
+	{
+		KeyEvent pressed = new ExtendedKeyEvent(new Canvas(), KeyEvent.KEY_PRESSED, KeyEvent.VK_T, 't');
+
+		chatboxInputManager.processKeyPressed(pressed);
+
+		assertTrue(chatboxInputManager.isTyping());
+		assertTrue(pressed.isConsumed());
+
+		KeyEvent typed = new KeyEvent(new Canvas(), KeyEvent.KEY_TYPED, 0, 0, KeyEvent.VK_UNDEFINED, 't');
+		chatboxInputManager.processKeyTyped(typed);
+
+		assertTrue(typed.isConsumed());
+
+		KeyEvent secondTyped = new KeyEvent(new Canvas(), KeyEvent.KEY_TYPED, 0, 0, KeyEvent.VK_UNDEFINED, 't');
+		chatboxInputManager.processKeyTyped(secondTyped);
+
+		assertFalse(secondTyped.isConsumed());
+	}
+
+	@Test
+	public void testShiftSemicolonActivatesColonChatShortcut()
+	{
+		KeyEvent pressed = new KeyEvent(new Canvas(), KeyEvent.KEY_PRESSED, 0,
+			KeyEvent.SHIFT_DOWN_MASK, KeyEvent.VK_SEMICOLON, ';');
+
+		chatboxInputManager.processKeyPressed(pressed);
+
+		assertTrue(chatboxInputManager.isTyping());
+		assertFalse(pressed.isConsumed());
+	}
+
+	@Test
+	public void testKeyRemappingDoesNotResetEnabledGlobalChat()
+	{
+		chatboxInputManager.setKeyRemappingPluginEnabled(true);
+		chatboxInputManager.setKeyRemappingPluginEnabled(false);
+
+		verify(clientThread, never()).invoke(any(Runnable.class));
+	}
+
+	@Test
+	public void testKeyRemappingUpdatesDisabledGlobalChat()
+	{
+		when(config.pressEnterToChat()).thenReturn(false);
+
+		chatboxInputManager.setKeyRemappingPluginEnabled(true);
+
+		verify(clientThread, times(1)).invoke(any(Runnable.class));
+	}
+
+	private static class ExtendedKeyEvent extends KeyEvent
+	{
+		private final int extendedKeyCode;
+
+		private ExtendedKeyEvent(Canvas source, int id, int keyCode, char keyChar)
+		{
+			super(source, id, 0, 0, keyCode, keyChar);
+			extendedKeyCode = keyCode;
+		}
+
+		@Override
+		public int getExtendedKeyCode()
+		{
+			return extendedKeyCode;
+		}
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/input/KeyManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/input/KeyManagerTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026, Endriti
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.input;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.awt.Canvas;
+import java.awt.event.KeyEvent;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.client.eventbus.EventBus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KeyManagerTest
+{
+	@Inject
+	private KeyManager keyManager;
+
+	@Mock
+	@Bind
+	private Client client;
+
+	@Mock
+	@Bind
+	private EventBus eventBus;
+
+	@Mock
+	@Bind
+	private ChatboxInputManager chatboxInputManager;
+
+	@Before
+	public void setUp()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+	}
+
+	@Test
+	public void testChatInputSkipsHotkeyListeners()
+	{
+		when(chatboxInputManager.isChatInputActive()).thenReturn(true);
+
+		RecordingChatListener chatListener = new RecordingChatListener();
+		RecordingKeyListener hotkeyListener = new RecordingKeyListener();
+		keyManager.registerKeyListener(chatListener);
+		keyManager.registerKeyListener(hotkeyListener);
+
+		keyManager.processKeyPressed(keyEvent(KeyEvent.KEY_PRESSED));
+		keyManager.processKeyTyped(keyEvent(KeyEvent.KEY_TYPED));
+		keyManager.processKeyReleased(keyEvent(KeyEvent.KEY_RELEASED));
+
+		assertEquals(1, chatListener.pressed);
+		assertEquals(1, chatListener.typed);
+		assertEquals(1, chatListener.released);
+		assertEquals(0, hotkeyListener.pressed);
+		assertEquals(0, hotkeyListener.typed);
+		assertEquals(1, hotkeyListener.released);
+	}
+
+	@Test
+	public void testConsumedChatActivationDoesNotDispatch()
+	{
+		doAnswer(invocation ->
+		{
+			KeyEvent event = invocation.getArgument(0);
+			event.consume();
+			return null;
+		}).when(chatboxInputManager).processKeyPressed(any(KeyEvent.class));
+
+		RecordingKeyListener listener = new RecordingKeyListener();
+		keyManager.registerKeyListener(listener);
+
+		keyManager.processKeyPressed(keyEvent(KeyEvent.KEY_PRESSED));
+
+		assertEquals(0, listener.pressed);
+	}
+
+	@Test
+	public void testClosingChatDoesNotDispatchHotkey()
+	{
+		when(chatboxInputManager.isChatInputActive()).thenReturn(true, false);
+
+		RecordingKeyListener listener = new RecordingKeyListener();
+		keyManager.registerKeyListener(listener);
+		keyManager.processKeyPressed(keyEvent(KeyEvent.KEY_PRESSED));
+
+		assertEquals(0, listener.pressed);
+	}
+
+	@Test
+	public void testUnconsumedChatActivationDoesNotDispatchHotkey()
+	{
+		when(chatboxInputManager.isChatInputActive()).thenReturn(false, true);
+
+		RecordingKeyListener listener = new RecordingKeyListener();
+		keyManager.registerKeyListener(listener);
+		keyManager.processKeyPressed(keyEvent(KeyEvent.KEY_PRESSED));
+
+		assertEquals(0, listener.pressed);
+	}
+
+	private static KeyEvent keyEvent(int id)
+	{
+		if (id == KeyEvent.KEY_TYPED)
+		{
+			return new KeyEvent(new Canvas(), id, 0, 0, KeyEvent.VK_UNDEFINED, 'q');
+		}
+
+		return new KeyEvent(new Canvas(), id, 0, 0, KeyEvent.VK_Q, 'q');
+	}
+
+	private static class RecordingKeyListener implements KeyListener
+	{
+		int pressed;
+		int typed;
+		int released;
+
+		@Override
+		public void keyTyped(KeyEvent e)
+		{
+			typed++;
+		}
+
+		@Override
+		public void keyPressed(KeyEvent e)
+		{
+			pressed++;
+		}
+
+		@Override
+		public void keyReleased(KeyEvent e)
+		{
+			released++;
+		}
+	}
+
+	private static class RecordingChatListener extends RecordingKeyListener
+	{
+		@Override
+		public boolean isEnabledOnChatInput()
+		{
+			return true;
+		}
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/bank/BankPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/bank/BankPluginTest.java
@@ -36,6 +36,7 @@ import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
+import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.game.ItemManager;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -62,6 +63,10 @@ public class BankPluginTest
 	@Mock
 	@Bind
 	private BankConfig bankConfig;
+
+	@Mock
+	@Bind
+	private RuneLiteConfig runeLiteConfig;
 
 	@Inject
 	private BankPlugin bankPlugin;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/keyremapping/KeyRemappingListenerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/keyremapping/KeyRemappingListenerTest.java
@@ -30,8 +30,8 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import javax.inject.Inject;
-import net.runelite.api.Client;
 import net.runelite.client.config.ModifierlessKeybind;
+import net.runelite.client.input.ChatboxInputManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,11 +50,7 @@ public class KeyRemappingListenerTest
 
 	@Mock
 	@Bind
-	private Client client;
-
-	@Mock
-	@Bind
-	private KeyRemappingPlugin keyRemappingPlugin;
+	private ChatboxInputManager chatboxInputManager;
 
 	@Mock
 	@Bind
@@ -76,7 +72,7 @@ public class KeyRemappingListenerTest
 		when(keyRemappingConfig.left()).thenReturn(new ModifierlessKeybind(KeyEvent.VK_A, 0));
 		when(keyRemappingConfig.right()).thenReturn(new ModifierlessKeybind(KeyEvent.VK_D, 0));
 
-		when(keyRemappingPlugin.chatboxFocused()).thenReturn(true);
+		when(chatboxInputManager.chatboxFocused()).thenReturn(true);
 
 		KeyEvent event = mock(KeyEvent.class);
 		when(event.getKeyChar()).thenReturn('d');
@@ -98,7 +94,7 @@ public class KeyRemappingListenerTest
 
 		verify(event).consume();
 
-		lenient().when(keyRemappingPlugin.isTyping()).thenReturn(true); // release handler no longer checks this
+		lenient().when(chatboxInputManager.isTyping()).thenReturn(true); // release handler no longer checks this
 		// with the plugin now in typing mode, previously pressed and remapped keys should still be mapped
 		// on key release regardless
 		event = mock(KeyEvent.class);
@@ -113,8 +109,8 @@ public class KeyRemappingListenerTest
 	{
 		when(keyRemappingConfig.space()).thenReturn(new ModifierlessKeybind(KeyEvent.VK_NUMPAD1, 0));
 
-		when(keyRemappingPlugin.chatboxFocused()).thenReturn(true);
-		when(keyRemappingPlugin.isDialogOpen()).thenReturn(true);
+		when(chatboxInputManager.chatboxFocused()).thenReturn(true);
+		when(chatboxInputManager.isDialogOpen()).thenReturn(true);
 
 		KeyEvent event = mock(KeyEvent.class);
 		when(event.getKeyChar()).thenReturn('1');
@@ -130,7 +126,7 @@ public class KeyRemappingListenerTest
 	public void testControlRemap()
 	{
 		when(keyRemappingConfig.control()).thenReturn(new ModifierlessKeybind(KeyEvent.VK_NUMPAD1, 0));
-		when(keyRemappingPlugin.chatboxFocused()).thenReturn(true);
+		when(chatboxInputManager.chatboxFocused()).thenReturn(true);
 
 		KeyEvent event = mock(KeyEvent.class);
 		when(event.getExtendedKeyCode()).thenReturn(KeyEvent.VK_NUMPAD1); // for keybind matches()


### PR DESCRIPTION
## Summary
- move "Key Remapping" plugins press-to-chat handling into the core input pipeline so it works with all plugin hotkeys.
- allow a configurable chat activation key while preserving `/` and `:` chat shortcuts
- suppress plugin hotkeys while chat is active, with explicit opt-ins for chat-aware listeners
- migrate Key Remapping to use the shared chat state

## Testing
- manually tested different plugins with hotkeys
- verified activation keys are not inserted into chat and plugin hotkeys resume after chat closes

## The Problem

Currently, if you set a single-letter hotkey (like "A", "B", "C", etc) in any RuneLite plugin, that key is permanently disabled from being typed in the chat box. While the "Key Remapping" plugin has a great "Press Enter to Chat" feature that solves this for its own remapped keys, it does not apply universally. If I bind "A" in the Ground Items plugin, I can never type the letter "A" in chat again, even if "Press Enter to Chat" is enabled in the Key Remapping plugin.

## Proposed Solution

Make "Press Key to Chat" a global, default RuneLite feature rather than keeping it isolated within the Key Remapping plugin.

Additionally, allow players to choose which key activates the chat. Instead of being locked to Enter, players should be able to bind chat activation to keys like T, Y, or U, which is standard practice in many other multiplayer games.

When "Press Enter to Chat" is enabled, it should intercept hotkey strokes for all plugins so that players can use single-letter hotkeys for their plugins without losing the ability to type those letters when the chat box is active.

Why this is useful

Accessibility & Comfort: Players coming from other games (like WoW, Dota 2, or League of Legends) heavily prefer using standard typable letters for hotkeys (Q, W, E, R, etc.) because they are close to the left hand.

Avoids Clunky Modifiers: The current workaround is using modifier keys (like Ctrl + Q), which is less ergonomic and limits quick reactions.

Consistency: It standardizes how hotkeys interact with the chat box across every plugin, rather than leaving it up to individual plugin developers to implement their own chat-blocking workarounds.