### PR TITLE
config: show world type in the rsprofile default tooltip

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
@@ -468,6 +468,11 @@ class ProfilePanel extends PluginPanel
 					if (defaultForRsProfiles == null || defaultForRsProfiles.isEmpty())
 					{
 						tooltip.append("Set profile as default for the current RuneScape account");
+						final RuneScapeProfileType currentType = configManager.getConfiguration(ConfigManager.RSPROFILE_GROUP, configManager.getRSProfileKey(), ConfigManager.RSPROFILE_TYPE, RuneScapeProfileType.class);
+						if (currentType != null && currentType != RuneScapeProfileType.STANDARD)
+						{
+							tooltip.append(" on ").append(Text.titleCase(currentType)).append(" worlds");
+						}
 					}
 					else
 					{


### PR DESCRIPTION
_Reinstates #20224, which auto-closed when I accidentally deleted my fork. Same commit, unchanged._

### Problem

The "set as default" link button on a profile card binds the profile to the current RuneScape account *and* world type. An account can hold a different default profile per `RuneScapeProfileType` (Standard / League / Deadman), and the "default for" tooltip already shows this by labelling non-standard types, e.g. `Spryt (Raging Echoes League)`.

The tooltip shown before you set it only says:

> Set profile as default for the current RuneScape account

That gives no hint the binding is world-type specific. Without reading the code, there is no way to tell that clicking the link on a Leagues or Deadman world binds the profile to that world type rather than the account globally. It leaves the per-world-type profile behaviour undiscoverable.

### Change

When the current profile's world type is non-standard, append it to the set tooltip, matching how the existing "default for" branch already labels types:

- Standard worlds (unchanged): `Set profile as default for the current RuneScape account`
- League and Deadman worlds: `Set profile as default for the current RuneScape account on Raging Echoes League worlds`

The world type comes from the same source as the adjacent code (the current `getRSProfileKey()` plus `RSPROFILE_TYPE`), so there are no new dependencies and no behaviour change, only the tooltip text.