### PR TITLE
config: allow config items to render their control below the label

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigItem.java
@@ -48,4 +48,11 @@ public @interface ConfigItem
 	boolean secret() default false;
 
 	String section() default "";
+
+	/**
+	 * Render the control on its own line below the name, rather than to the
+	 * right of it. Useful when the control is wide, for example a dropdown with
+	 * long options, that would otherwise truncate the name.
+	 */
+	boolean below() default false;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -358,17 +358,18 @@ class ConfigPanel extends PluginPanel
 			PluginListItem.addLabelPopupMenu(configEntryName, createResetMenuItem(pluginConfig, cid));
 			item.add(configEntryName, BorderLayout.CENTER);
 
+			String controlPosition = cid.getItem().below() ? BorderLayout.SOUTH : BorderLayout.EAST;
 			if (cid.getType() == boolean.class)
 			{
-				item.add(createCheckbox(cd, cid), BorderLayout.EAST);
+				item.add(createCheckbox(cd, cid), controlPosition);
 			}
 			else if (cid.getType() == int.class)
 			{
-				item.add(createIntSpinner(cd, cid), BorderLayout.EAST);
+				item.add(createIntSpinner(cd, cid), controlPosition);
 			}
 			else if (cid.getType() == double.class)
 			{
-				item.add(createDoubleSpinner(cd, cid), BorderLayout.EAST);
+				item.add(createDoubleSpinner(cd, cid), controlPosition);
 			}
 			else if (cid.getType() == String.class)
 			{
@@ -376,34 +377,34 @@ class ConfigPanel extends PluginPanel
 			}
 			else if (cid.getType() == Color.class)
 			{
-				item.add(createColorPicker(cd, cid), BorderLayout.EAST);
+				item.add(createColorPicker(cd, cid), controlPosition);
 			}
 			else if (cid.getType() == Dimension.class)
 			{
-				item.add(createDimension(cd, cid), BorderLayout.EAST);
+				item.add(createDimension(cd, cid), controlPosition);
 			}
 			else if (cid.getType() instanceof Class && ((Class<?>) cid.getType()).isEnum())
 			{
-				item.add(createComboBox(cd, cid), BorderLayout.EAST);
+				item.add(createComboBox(cd, cid), controlPosition);
 			}
 			else if (cid.getType() == Keybind.class || cid.getType() == ModifierlessKeybind.class)
 			{
-				item.add(createKeybind(cd, cid), BorderLayout.EAST);
+				item.add(createKeybind(cd, cid), controlPosition);
 			}
 			else if (cid.getType() == Notification.class)
 			{
-				item.add(createNotification(cd, cid), BorderLayout.EAST);
+				item.add(createNotification(cd, cid), controlPosition);
 			}
 			else if (cid.getType() == FontType.class)
 			{
-				item.add(createFont(cd, cid), BorderLayout.EAST);
+				item.add(createFont(cd, cid), controlPosition);
 			}
 			else if (cid.getType() instanceof ParameterizedType)
 			{
 				ParameterizedType parameterizedType = (ParameterizedType) cid.getType();
 				if (parameterizedType.getRawType() == Set.class)
 				{
-					item.add(createList(cd, cid), BorderLayout.EAST);
+					item.add(createList(cd, cid), controlPosition);
 				}
 			}
 


### PR DESCRIPTION
### Problem

A config item's control (dropdown, spinner, colour picker, etc.) is added to the right of its name. When the name is long it gets truncated, since the control takes a fixed slice of the row width. It shows up most with enum dropdowns whose values are wide, where the name can be cut down to a few characters.

`String` items already sidestep this: their text field renders on its own line below the name.

### Change

Add a `below` flag to `@ConfigItem`. When set, the control is added to `BorderLayout.SOUTH` instead of `BorderLayout.EAST`, so the name keeps its own line and the control gets the full width beneath it. This applies to every control type, not only text fields.

It defaults to `false`, so existing config items render exactly as before.