### PR TITLE
worldhopper: add packet loss display and color options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -216,6 +216,6 @@ public interface WorldHopperConfig extends Config
 	)
 	default PacketLossColor packetLossColor()
 	{
-		return PacketLossColor.YELLOW;
+		return PacketLossColor.RED;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2018, Lotto <https://github.com/devLotto>
  * Copyright (c) 2019, gregg1494 <https://github.com/gregg1494>
- * Copyright (c) 2026, StaySleeping <https://github.com/StaySleeping>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018, Lotto <https://github.com/devLotto>
  * Copyright (c) 2019, gregg1494 <https://github.com/gregg1494>
+ * Copyright (c) 2026, StaySleeping <https://github.com/StaySleeping>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,10 +26,13 @@
  */
 package net.runelite.client.plugins.worldhopper;
 
+import java.awt.Color;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.util.Collections;
 import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -38,6 +42,39 @@ import net.runelite.client.config.Keybind;
 public interface WorldHopperConfig extends Config
 {
 	String GROUP = "worldhopper";
+
+	@AllArgsConstructor
+	enum PacketLossDisplayMode
+	{
+		ALWAYS("Always"),
+		NEVER("Never"),
+		GREATER_THAN_ZERO(">0%");
+
+		private final String name;
+
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	enum PacketLossColor
+	{
+		YELLOW("Yellow", Color.YELLOW),
+		RED("Red", Color.RED);
+
+		private final String name;
+		private final Color color;
+
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+	}
 
 	@ConfigItem(
 		keyName = "previousKey",
@@ -158,5 +195,27 @@ public interface WorldHopperConfig extends Config
 	default boolean displayPing()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "displayPacketLoss",
+		name = "Display packet loss",
+		description = "Displays packet loss percentage or not.",
+		position = 12
+	)
+	default PacketLossDisplayMode displayPacketLoss()
+	{
+		return PacketLossDisplayMode.GREATER_THAN_ZERO;
+	}
+
+	@ConfigItem(
+		keyName = "packetLossColor",
+		name = "Packet loss color",
+		description = "Color of the packet loss overlay text.",
+		position = 13
+	)
+	default PacketLossColor packetLossColor()
+	{
+		return PacketLossColor.YELLOW;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPingOverlay.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019, gregg1494 <https://github.com/gregg1494>
  * Copyright (c) 2026, Adam <Adam@sigterm.info>
+ * Copyright (c) 2026, StaySleeping <https://github.com/StaySleeping>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -90,12 +91,16 @@ class WorldHopperPingOverlay extends Overlay
 			xOffset += textWidth + fm.stringWidth(" ");
 		}
 
-		int percRetransmit = worldHopperPlugin.retransmitCalculator.getRetransmitPercent();
-		if (percRetransmit > 0)
+		final WorldHopperConfig.PacketLossDisplayMode displayPacketLoss = worldHopperConfig.displayPacketLoss();
+		if (displayPacketLoss != WorldHopperConfig.PacketLossDisplayMode.NEVER)
 		{
-			String text = percRetransmit + "% loss";
-			Point point = new Point(width - fm.stringWidth(text) - xOffset, textHeight + Y_OFFSET);
-			OverlayUtil.renderTextLocation(graphics, point, text, Color.RED);
+			int percRetransmit = worldHopperPlugin.retransmitCalculator.getRetransmitPercent();
+			if (displayPacketLoss == WorldHopperConfig.PacketLossDisplayMode.ALWAYS || percRetransmit > 0)
+			{
+				String text = percRetransmit + "% loss";
+				Point point = new Point(width - fm.stringWidth(text) - xOffset, textHeight + Y_OFFSET);
+				OverlayUtil.renderTextLocation(graphics, point, text, worldHopperConfig.packetLossColor().getColor());
+			}
 		}
 
 		return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPingOverlay.java
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2019, gregg1494 <https://github.com/gregg1494>
  * Copyright (c) 2026, Adam <Adam@sigterm.info>
- * Copyright (c) 2026, StaySleeping <https://github.com/StaySleeping>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
the red text of the packet loss display popping up looks too similar to a player appearing on your minimap. added some options to make it either never show, always show or the current functionality where it shows when >0%. also added an option to pick either red or yellow so it can be the same colour as the ping it appears next to. I was going to allow it to be a colour picker but i thought it didnt make sense since the ping's colour can't be picked, if this is an issue i can change it back to just a regular colour picker or feel free to change it yourself.