### PR TITLE
gpu: describe static xyz as a four-component short attribute

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/Zone.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/Zone.java
@@ -156,7 +156,7 @@ class Zone
 		glBindBuffer(GL_ARRAY_BUFFER, buffer);
 
 		glEnableVertexAttribArray(0);
-		glVertexAttribPointer(0, 3, GL_SHORT, false, VERT_SIZE, 0);
+		glVertexAttribPointer(0, 4, GL_SHORT, false, VERT_SIZE, 0);
 
 		glEnableVertexAttribArray(1);
 		glVertexAttribIPointer(1, 1, GL_INT, VERT_SIZE, 8);


### PR DESCRIPTION
Static zone geometry declares its xyz position as a three-component `GL_SHORT` attribute:

```java
glVertexAttribPointer(0, 3, GL_SHORT, false, VERT_SIZE, 0);
```

D3D12/DXGI has no native three-component 16-bit vertex format, so translation layers such as OpenGLOn12 have to emulate it. On a Windows machine running through OpenGLOn12, static opaque draws dominated frame time — suppressing them alone raised the frame rate to ~100 FPS. Buffer mapping instead of `glBufferSubData`, Mesa threaded dispatch, replacing `glMultiDrawArrays`, removing per-zone uniform changes, sharing VAOs, and drastically simplifying both the vertex and fragment shaders all made no material difference.

The vertex record is already 20 bytes with a padding short after xyz (attribute 1 starts at byte offset 8), so exposing four components costs nothing in memory or bandwidth and lets the translation layer select a native 4x16 format. `vert.glsl` declares `layout(location = 0) in vec3 vertf`, so the fourth component is simply dropped by the shader and rendering is unchanged.

With this one-line change the full scene rendered at ~160 FPS even at maximum draw distance.

Verified on native OpenGL as well (NVIDIA, Windows 11 arm64 and win64): the scene renders identically with no regression, so the change is a no-op for drivers that already support 3x16 natively.

Context and the full investigation: https://github.com/runelite/runelite/issues/19804#issuecomment-5125937354
