### PR TITLE
slayer: support mortimer task length modifier

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -403,6 +403,12 @@ public class SlayerPlugin extends Plugin
 			}
 
 			int initialAmount = client.getVarpValue(VarPlayerID.SLAYER_COUNT_ORIGINAL);
+			if (client.getVarbitValue(VarbitID.SLAYER_MODIFIER_ID) == 2)
+			{
+				boolean isNegative = client.getVarbitValue(VarbitID.SLAYER_MODIFIER_NEGATIVE) == 1;
+				int modifierValue = client.getVarbitValue(VarbitID.SLAYER_MODIFIER_VALUE);
+				initialAmount += isNegative ? -modifierValue : modifierValue;
+			}
 
 			if (loginFlag)
 			{


### PR DESCRIPTION
As far as I can tell Mortimer does not have a transmitted Varbit or Varplayer for the completed task count. We could leave it as it, hide the streak from the infobox when Mortimer is the slayer master, or implement chat message parsing.
```
<col=ef1020>You've completed </col>0 Mortimer tasks<col=ef1020> and currently have a total of </col>240 points<col=ef1020>.
<col=ef1020>You've completed </col>1 Mortimer task<col=ef1020>; return to a Slayer master.</col>
<col=ef1020>You've completed </col>2 Mortimer tasks<col=ef1020> and received </col>15 points<col=ef1020>, giving you a total of </col>255<col=ef1020>; return to a Slayer master.</col>
<col=ef1020>You've completed </col>3 Mortimer tasks<col=ef1020> and received </col>10 points<col=ef1020>, giving you a total of </col>265<col=ef1020>; return to a Slayer master.</col>
```