### PR TITLE
chatcommands: read the adventure log owner from either menu interface

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -145,8 +145,6 @@ public class ChatCommandsPlugin extends Plugin
 	private static final String CA_COMMAND = "!ca";
 	private static final String CLOG_COMMAND = "!clog";
 
-	@VisibleForTesting
-	static final int ADV_LOG_EXPLOITS_TEXT_INDEX = 1;
 	static final int COL_LOG_ENTRY_HEADER_TITLE_INDEX = 0;
 
 	private static final Map<String, String> KILLCOUNT_RENAMES = ImmutableMap.of(
@@ -681,6 +679,70 @@ public class ChatCommandsPlugin extends Plugin
 		return Double.parseDouble(timeString);
 	}
 
+	/**
+	 * The adventure log owner, or null when the loaded menu is not an
+	 * adventure log.
+	 *
+	 * <p>The log opens in one of two menu interfaces depending on the player's
+	 * interface style setting, so both are read. The title sits at a different
+	 * child index in each and is surrounded by null and non-text children, so
+	 * each container is scanned for the first line matching the title pattern
+	 * rather than indexed.
+	 */
+	private String readAdventureLogOwner()
+	{
+		String owner = readAdventureLogOwner(InterfaceID.MenuNew.TITLE);
+		return owner != null ? owner : readAdventureLogOwner(InterfaceID.Menu.LJ_LAYER2);
+	}
+
+	private String readAdventureLogOwner(int componentId)
+	{
+		Widget container = client.getWidget(componentId);
+		if (container == null)
+		{
+			return null;
+		}
+
+		String own = matchAdventureLogOwner(container.getText());
+		if (own != null)
+		{
+			return own;
+		}
+
+		Widget[] children = container.getChildren();
+		if (children == null)
+		{
+			return null;
+		}
+
+		for (Widget child : children)
+		{
+			if (child == null)
+			{
+				continue;
+			}
+
+			String found = matchAdventureLogOwner(child.getText());
+			if (found != null)
+			{
+				return found;
+			}
+		}
+
+		return null;
+	}
+
+	private static String matchAdventureLogOwner(String text)
+	{
+		if (text == null)
+		{
+			return null;
+		}
+
+		Matcher matcher = ADVENTURE_LOG_TITLE_PATTERN.matcher(Text.removeTags(text));
+		return matcher.find() ? matcher.group(1) : null;
+	}
+
 	@VisibleForTesting
 	static String secondsToTimeString(double seconds)
 	{
@@ -735,15 +797,11 @@ public class ChatCommandsPlugin extends Plugin
 		{
 			advLogLoaded = false;
 
-			Widget adventureLog = client.getWidget(InterfaceID.Menu.LJ_LAYER2);
+			String owner = readAdventureLogOwner();
 
-			if (adventureLog != null)
+			if (owner != null)
 			{
-				Matcher advLogExploitsText = ADVENTURE_LOG_TITLE_PATTERN.matcher(adventureLog.getChild(ADV_LOG_EXPLOITS_TEXT_INDEX).getText());
-				if (advLogExploitsText.find())
-				{
-					pohOwner = advLogExploitsText.group(1);
-				}
+				pohOwner = owner;
 			}
 		}
 
@@ -883,6 +941,7 @@ public class ChatCommandsPlugin extends Plugin
 		switch (widget.getGroupId())
 		{
 			case InterfaceID.MENU:
+			case InterfaceID.MENU_NEW:
 				advLogLoaded = true;
 				break;
 			case InterfaceID.KILL_LOG:

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
@@ -83,6 +83,7 @@ import static org.mockito.ArgumentMatchers.nullable;
 import org.mockito.Mock;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -1080,6 +1081,20 @@ public class ChatCommandsPluginTest
 	@Test
 	public void testCounters()
 	{
+		// Original interface style.
+		testCounters(InterfaceID.MENU, InterfaceID.Menu.LJ_LAYER2);
+	}
+
+	@Test
+	public void testCountersNewMenu()
+	{
+		// Newer interface style: the same adventure log, a different menu
+		// interface. Both are live and the player's setting decides which.
+		testCounters(InterfaceID.MENU_NEW, InterfaceID.MenuNew.TITLE);
+	}
+
+	private void testCounters(int menuGroupId, int titleComponentId)
+	{
 		final String[] log = {
 			"Chompy Hunting",
 			"Kills: <col=ffffff>1,003</col>",
@@ -1220,9 +1235,17 @@ public class ChatCommandsPluginTest
 		// adv log
 		Widget advLogWidget = mock(Widget.class);
 		Widget advLogExploitsTextWidget = mock(Widget.class);
-		when(advLogWidget.getChild(ChatCommandsPlugin.ADV_LOG_EXPLOITS_TEXT_INDEX)).thenReturn(advLogExploitsTextWidget);
 		when(advLogExploitsTextWidget.getText()).thenReturn("The Exploits of " + PLAYER_NAME);
-		when(client.getWidget(InterfaceID.Menu.LJ_LAYER2)).thenReturn(advLogWidget);
+		Widget advLogNonMatchingWidget = mock(Widget.class);
+		when(advLogNonMatchingWidget.getText()).thenReturn("");
+		// The title is a later dynamic child, surrounded by null and non-text
+		// children; the widget after it must never be read once matched.
+		Widget advLogDecoyWidget = mock(Widget.class);
+		lenient().when(advLogDecoyWidget.getText()).thenReturn("The Exploits of Someone Else");
+		when(advLogWidget.getChildren()).thenReturn(new Widget[]{
+			null, mock(Widget.class), advLogNonMatchingWidget,
+			advLogExploitsTextWidget, advLogDecoyWidget});
+		when(client.getWidget(titleComponentId)).thenReturn(advLogWidget);
 
 		// counters
 		when(client.getWidget(InterfaceID.Journalscroll.TEXTLAYER)).thenAnswer(a ->
@@ -1241,7 +1264,7 @@ public class ChatCommandsPluginTest
 		});
 
 		WidgetLoaded advLogEvent = new WidgetLoaded();
-		advLogEvent.setGroupId(InterfaceID.MENU);
+		advLogEvent.setGroupId(menuGroupId);
 		chatCommandsPlugin.onWidgetLoaded(advLogEvent);
 		chatCommandsPlugin.onGameTick(new GameTick());
 


### PR DESCRIPTION
The POH adventure log opens in one of two menu interfaces depending on the player's interface style setting: `MENU` (187) or `MENU_NEW` (947). The plugin only watches `MENU`, so for players on the newer style `pohOwner` is never captured. The boss kill log and pets paths tolerate a null owner and keep working, but the Counters personal-best parse requires an owner match, so it is silently skipped and those players record no adventure-log personal bests at all.

This watches both groups and reads the owner from whichever menu is present. The title sits at a different child index in each and is surrounded by null and non-text children, so each container is scanned for the first line matching the existing title pattern rather than read from a fixed index; `ADV_LOG_EXPLOITS_TEXT_INDEX` is no longer needed. Tags are stripped before matching, which is a no-op on the old interface.

Scope is chatcommands only. The deprecated `WidgetInfo.ADVENTURE_LOG` / `WidgetID.ADVENTURE_LOG_ID` mappings still reference the old interface and are left untouched as frozen legacy API.

Tested in-game on both settings: on the original style the owner resolves through `Menu.LJ_LAYER2`, on the newer style through `MenuNew.TITLE`, and the Counters scroll parses identically in both. The existing counters test now runs against both interfaces, with the title as a sparse dynamic child plus a decoy match after it, proving the scan stops at the first hit.
