### PR TITLE
bank: track bank open state via interface lifecycle

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -63,6 +63,7 @@ import net.runelite.api.gameval.VarClientID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.api.widgets.JavaScriptCallback;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.events.WidgetClosed;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.Keybind;
@@ -114,6 +115,7 @@ public class BankPlugin extends Plugin
 	private KeyManager keyManager;
 
 	private boolean forceRightClickFlag;
+	private boolean bankOpen;
 	private Multiset<Integer> itemQuantities; // bank item quantities for bank value search
 	private String searchString;
 	private ContainerPrices prices;
@@ -131,8 +133,7 @@ public class BankPlugin extends Plugin
 			Keybind keybind = config.searchKeybind();
 			if (keybind.matches(e))
 			{
-				Widget bankContainer = client.getWidget(InterfaceID.Bankmain.ITEMS);
-				if (bankContainer != null && !bankContainer.isSelfHidden())
+				if (bankOpen)
 				{
 					log.debug("Search hotkey pressed");
 					bankSearch.initSearch();
@@ -198,6 +199,7 @@ public class BankPlugin extends Plugin
 	@Override
 	protected void startUp()
 	{
+		bankOpen = false;
 		keyManager.registerKeyListener(searchHotkeyListener);
 	}
 
@@ -207,6 +209,7 @@ public class BankPlugin extends Plugin
 		keyManager.unregisterKeyListener(searchHotkeyListener);
 		clientThread.invokeLater(() -> bankSearch.reset(false));
 		forceRightClickFlag = false;
+		bankOpen = false;
 		itemQuantities = null;
 		searchString = null;
 	}
@@ -304,9 +307,23 @@ public class BankPlugin extends Plugin
 	@Subscribe
 	public void onWidgetLoaded(WidgetLoaded event)
 	{
+		if (event.getGroupId() == InterfaceID.BANKMAIN)
+		{
+			bankOpen = true;
+		}
+
 		if (event.getGroupId() == InterfaceID.SEED_VAULT && config.seedVaultValue())
 		{
 			clientThread.invokeLater(this::updateSeedVaultTotal);
+		}
+	}
+
+	@Subscribe
+	public void onWidgetClosed(WidgetClosed event)
+	{
+		if (event.getGroupId() == InterfaceID.BANKMAIN)
+		{
+			bankOpen = false;
 		}
 	}
 


### PR DESCRIPTION
Fixes #20371

## Problem

Pressing the bank search keybind and then closing the bank with the escape key leaves the keybind consumed. The bound key stops working for its normal in game function until the Bank plugin is disabled or the bank is reopened and closed in a different manner.

## Steps to reproduce

1. Set the bank search keybind to a key with a normal function (e.g. F3)
2. Open a bank
3. Open search (via the keybind or manually clicking the magnifying glass search button)
4. Close the bank with the escape key
5. Attempt to use the bound key for its normal function (it no longer switches tabs)

Closing the bank via the X button in the corner or by running away from the bank does not reproduce it.

## Cause

The hotkey listener gated `e.consume()` on the visibility of `InterfaceID.Bankmain.ITEMS`:

```java
Widget bankContainer = client.getWidget(InterfaceID.Bankmain.ITEMS);
if (bankContainer != null && !bankContainer.isSelfHidden())
```

After an escape close, that widget is still resident and its own hidden flag is not set, so the condition passes and the key is consumed even though the bank is closed.

Debug output: escape close followed by pressing the bound key:
```
15:46:17 [Client] BankPlugin - WIDGET CLOSED: 12
15:46:18 [AWT-EventQueue-0] BankPlugin - HOTKEY: bankContainer=true selfHidden=false
15:46:18 [AWT-EventQueue-0] BankPlugin - Search hotkey pressed
15:46:18 [AWT-EventQueue-0] KeyManager - Consuming key pressed ... keyText=F2
```

`WidgetClosed` fires correctly a second earlier; only the widget-visibility check is stale.

`isHidden()` is not a usable substitute - it walks the parent chain and throws `IllegalStateException: must be called on client thread` from the AWT key listener.

## Fix

Track bank interface open state from `WidgetLoaded` and `WidgetClosed` and gate the consume on that. The field is `volatile` because it is written on the client thread and read on AWT.

## Testing
- [x] Escape close, with and without search open
- [x] X button close
- [x] Walking away from bank
- [x] Search opened via keybind and via search button
- [x] Keybind still opens search normally; works again after reopening the bank
- [x] plugin disabled/re-enabled
- [x] bank open and search open, then red X close game, still works
- [x] bank tags enabled
- [x] group storage and seed vault - these worked before bug and still work after

## Known limitation

Enabling the plugin while a bank is already open leaves `bankOpen` false until the bank is reopened, since no `WidgetLoaded` fires. The keybind is inert in that window. The keybind works again for the search feature on the next bank open. This is a smaller failure than the current behavior, but I'm happy to handle it if preferred.