### PR TITLE
Special Attack Counter Thrall Mixup

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -260,15 +260,10 @@ public class SpecialCounterPlugin extends Plugin
 					return;
 				}
 
-				// Hitsplat order is [player range/mage hits, thrall hit, veng, player melee hits]
-				// If melee hit choose last, otherwise choose first for range/mage
-				boolean meleeHit = specialWeapon.getHitDelay(1) <= 1;
-				// Note: Elder maul has a delay of 2 but has its own case above. @KEVIN Look into this and resolve before PR
-				// Alternative: Add style parameter to SpecialWeapon
-				// Alternative 2: Track xp drops (and fake xp drops).
-				// Customizable xp drops plugin has a manual table for exact numbers but maybe we could get away with hit/miss
-				Hitsplat hitsplat = hitsplats.get(meleeHit ? hitsplats.size() - 1 : 0);
-				// Existing bug - splash spec with mage = 1 hitsplat and thrall takes it
+				// Hitsplat arrival order on the same tick: [delayed hits, thrall hit, veng, instant hits]
+				// All range and magic specs are delayed, all melee specs other than elder maul are instant
+				boolean delayedHit = specialWeapon.getHitDelay(1) > 1;
+				Hitsplat hitsplat = hitsplats.get(delayedHit ? 0 : hitsplats.size() - 1);
 				specialAttackHit(specialWeapon, hitsplat.getAmount(), lastSpecTarget);
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -246,10 +246,10 @@ public class SpecialCounterPlugin extends Plugin
 					return;
 				}
 
-				Hitsplat last = hitsplats.get(hitsplats.size() - 1);
-				Hitsplat secondToLast = hitsplats.get(hitsplats.size() - 2);
+				Hitsplat first = hitsplats.get(0);
+				Hitsplat second = hitsplats.get(1);
 
-				int hit = Math.min(last.getAmount(), 1) + Math.min(secondToLast.getAmount(), 1);
+				int hit = Math.min(first.getAmount(), 1) + Math.min(second.getAmount(), 1);
 
 				specialAttackHit(specialWeapon, hit, lastSpecTarget);
 			}
@@ -260,9 +260,15 @@ public class SpecialCounterPlugin extends Plugin
 					return;
 				}
 
-				// The weapon hitsplat is always last, after other hitsplats which occur on the same tick such as from
-				// venge or thralls.
-				Hitsplat hitsplat = hitsplats.get(hitsplats.size() - 1);
+				// Hitsplat order is [player range/mage hits, thrall hit, veng, player melee hits]
+				// If melee hit choose last, otherwise choose first for range/mage
+				boolean meleeHit = specialWeapon.getHitDelay(1) <= 1;
+				// Note: Elder maul has a delay of 2 but has its own case above. @KEVIN Look into this and resolve before PR
+				// Alternative: Add style parameter to SpecialWeapon
+				// Alternative 2: Track xp drops (and fake xp drops).
+				// Customizable xp drops plugin has a manual table for exact numbers but maybe we could get away with hit/miss
+				Hitsplat hitsplat = hitsplats.get(meleeHit ? hitsplats.size() - 1 : 0);
+				// Existing bug - splash spec with mage = 1 hitsplat and thrall takes it
 				specialAttackHit(specialWeapon, hitsplat.getAmount(), lastSpecTarget);
 			}
 


### PR DESCRIPTION
Fixes issues https://github.com/runelite/runelite/issues/19722 and https://github.com/runelite/runelite/issues/20315. 
More comprehensive solution than https://github.com/runelite/runelite/pull/20029, included for reference.

## Summary

Hitspats are not attached to a particular weapon. Special Attack Counter needs to figure out what hit belongs to the player's special attack and which belongs to a thrall or vengance hit. Currently range and magic specs get overridden by other hits when they land on the same tick. 

Examples:
Thrall hits a 2 and eye hits a 20. Special attack counter shows eye with a value of 2.
Thrall hits a 0 and eye hits a 20. Special attack counter shows nothing.
Thrall hits a 2 and dorg bow hits 10. Special attack counter shows 2. 
Thrall hits a 0 and ralos hits twice. Special attack counter shows 1 ralos. 
Thrall hits a 2 and ralos misses twice. Special attack counter shows 1 ralos. 

## Solution 

Melee weapon hitsplats are delivered after thrall and veng hits, but range and magic hits are delivered before. Melee and range/mage weapons is a useful description but the actual difference seems to be the hit delay. The elder maul hitsplat actually lands a tick later and gets delivered first (although elder maul has a special case that doesn't exercise the code path in this PR). I experimentally verified that with all range and magic spec weapons.

## Reproduction and testing steps

The easiest way to reproduce is by summoning a thrall and lining up a special attack with the thrall's hitsplat. I verified the order with veng as well but didn't include in these this list. Pre-summon a mage thrall in range of an NPC then follow the per-weapon instructions. There's RNG involved in whether the thrall and special attack hits. 

- eye - 5t + eye spec
- ralos - 4t + ralos spec
- accursed sceptre - 4t + accursed sceptre spec
- seercull - 4t  + seercull spec
- dorg c'bow - 3t + dorg c'bow spec
- maul - 4t + maul (working but included for regression)
- bgs - 5t + bgs spec (working but included for regression)

### Miscellaneous

Splashed magic attacks don't give a hitsplat and can encounter similar issues with thrall hitsplats counting. I think  `lastSpecHpChange` would be the best way to address that but it's earlier in the process than these changes so I left it out.
I didn't experiment with recoils/suffering or other indirect damage attributed to the player like verzik's zap. 
I didn't explicitly test with party integration as those code paths weren't affected.