### PR TITLE
Menu Entry Swapper: Add option to equip items with ctrl click when bank is open

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/CtrlEquipMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/CtrlEquipMode.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, Zach <https://github.com/zacharydwaller>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.menuentryswapper;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CtrlEquipMode
+{
+	EXTRA_OP("Eat/Wield/Etc.", 9, 9, 0, 0),
+	OFF("Off", 0, 0, 0, 0);
+
+	private final String name;
+	private final int identifier;
+	private final int identifierDepositBox;
+	private final int identifierGroupStorage;
+	private final int identifierChambersStorageUnit;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -568,6 +568,17 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "bankEquipCtrlClick",
+			name = "Bank Equip ctrl-click",
+			description = "Swaps the behavior of ctrl-click when in a bank.",
+			section = uiSection
+	)
+	default CtrlEquipMode bankEquipCtrlClick()
+	{
+		return CtrlEquipMode.OFF;
+	}
+
+	@ConfigItem(
 		keyName = "shopBuy",
 		name = "Shop buy shift-click",
 		description = "Swaps the Buy options with Value on items in shops when shift is held.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1409,6 +1409,21 @@ public class MenuEntrySwapperPlugin extends Plugin
 			return true;
 		}
 
+		if (ctrlModifier() && config.bankEquipCtrlClick() != CtrlEquipMode.OFF
+				&& type == MenuAction.CC_OP
+				&& menuEntry.getIdentifier() == (isGroupStoragePlayerInventory || isChambersOfXericStorageUnitPlayerInventory ? 1 : 2)
+				&& (menuEntry.getOption().startsWith("Deposit-") || menuEntry.getOption().startsWith("Store") || menuEntry.getOption().startsWith("Donate")))
+		{
+			CtrlEquipMode ctrlEquipMode = config.bankEquipCtrlClick();
+			final int opId = isDepositBoxPlayerInventory ? ctrlEquipMode.getIdentifierDepositBox()
+					: isChambersOfXericStorageUnitPlayerInventory ? ctrlEquipMode.getIdentifierChambersStorageUnit()
+					: isGroupStoragePlayerInventory ? ctrlEquipMode.getIdentifierGroupStorage()
+					: ctrlEquipMode.getIdentifier();
+			final MenuAction action = opId >= 6 ? MenuAction.CC_OP_LOW_PRIORITY : MenuAction.CC_OP;
+			bankModeSwap(menu, action, opId);
+			return true;
+		}
+
 		// Swap to shift-click withdraw behavior
 		// Deposit- op 1 is the current withdraw amount 1/5/10/x
 		if (shiftModifier() && config.bankWithdrawShiftClick() != ShiftWithdrawMode.OFF
@@ -1885,6 +1900,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 	private boolean shiftModifier()
 	{
 		return client.isKeyPressed(KeyCode.KC_SHIFT);
+	}
+
+	private boolean ctrlModifier()
+	{
+		return client.isKeyPressed(KeyCode.KC_CONTROL);
 	}
 
 	private Integer getObjectSwapConfig(boolean shift, int objectId)


### PR DESCRIPTION
Simple modification to add the ability to ctrl-click items to equip them when the bank is open. 