### PR TITLE
banktags: add filter to the tag tab tab

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.banktags;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Keybind;
 
 @ConfigGroup("banktags")
 public interface BankTagsConfig extends Config
@@ -92,6 +93,17 @@ public interface BankTagsConfig extends Config
 		description = ""
 	)
 	void position(int idx);
+
+	@ConfigItem(
+		keyName = "filterTagTabsKeybind",
+		name = "Filter tag tabs shortcut",
+		description = "Keyboard shortcut for filtering the tag tab tab.",
+		position = 5
+	)
+	default Keybind filterTagTabsKeybind()
+	{
+		return Keybind.NOT_SET;
+	}
 
 	@ConfigItem(
 		keyName = "tab",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.awt.event.KeyEvent;
 import javax.inject.Inject;
 import javax.inject.Named;
 import lombok.Getter;
@@ -53,7 +54,10 @@ import net.runelite.api.gameval.VarClientID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.config.Keybind;
 import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.input.KeyListener;
+import net.runelite.client.input.KeyManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.ItemManager;
@@ -127,6 +131,40 @@ public class BankTagsPlugin extends Plugin implements BankTagsService
 
 	@Inject
 	private TabInterface tabInterface;
+
+	@Inject
+	private KeyManager keyManager;
+
+	private final KeyListener filterHotkeyListener = new KeyListener()
+	{
+		@Override
+		public void keyTyped(KeyEvent e)
+		{
+		}
+
+		@Override
+		public void keyPressed(KeyEvent e)
+		{
+			Keybind keybind = config.filterTagTabsKeybind();
+			if (keybind.matches(e))
+			{
+				e.consume();
+				clientThread.invoke(() ->
+				{
+					Widget bank = client.getWidget(InterfaceID.Bankmain.ITEMS_CONTAINER);
+					if (bank != null && !bank.isHidden())
+					{
+						tabInterface.filterTagTabs();
+					}
+				});
+			}
+		}
+
+		@Override
+		public void keyReleased(KeyEvent e)
+		{
+		}
+	};
 
 	@Inject
 	private LayoutManager layoutManager;
@@ -207,6 +245,7 @@ public class BankTagsPlugin extends Plugin implements BankTagsService
 		spriteManager.addSpriteOverrides(TabSprites.values());
 		eventBus.register(tabInterface);
 		layoutManager.register();
+		keyManager.registerKeyListener(filterHotkeyListener);
 		clientThread.invokeLater(this::reinitBank);
 	}
 
@@ -215,6 +254,7 @@ public class BankTagsPlugin extends Plugin implements BankTagsService
 	{
 		eventBus.unregister(tabInterface);
 		layoutManager.unregister();
+		keyManager.unregisterKeyListener(filterHotkeyListener);
 		clientThread.invokeLater(() ->
 		{
 			// since the tab interface is unregistered from the eventbus, manually deinit it

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -114,6 +114,7 @@ public class TabInterface
 	private static final String TAG_INVENTORY = "Tag-inventory";
 	private static final String TAGTABS = "tagtabs";
 	private static final String OPEN_TAB_MENU = "View tag tabs";
+	private static final String FILTER_TAB_MENU = "Filter tag tabs";
 	static final String ENABLE_LAYOUT = "Enable layout";
 	static final String DISABLE_LAYOUT = "Disable layout";
 	static final String REMOVE_LAYOUT = "Remove-layout";
@@ -140,6 +141,7 @@ public class TabInterface
 	private static final int NEWTAB_OP_NEW_TAB = 1;
 	private static final int NEWTAB_OP_IMPORT_TAB = 2;
 	private static final int NEWTAB_OP_OPEN_TAB_MENU = 3;
+	private static final int NEWTAB_OP_FILTER_TAB_MENU = 4;
 	private static final int TAGTAB_CHILD_OFFSET = 4;
 
 	private final Client client;
@@ -162,6 +164,7 @@ public class TabInterface
 	private int activeOptions;
 	@Getter
 	private boolean tagTabActive;
+	private String tagTabFilter;
 	private int tagTabFirstChildIdx = -1;
 	private int tabScrollOffset;
 	private Instant startScroll = Instant.now();
@@ -343,6 +346,7 @@ public class TabInterface
 		newTab.setAction(NEWTAB_OP_NEW_TAB, NEW_TAB);
 		newTab.setAction(NEWTAB_OP_IMPORT_TAB, IMPORT_TAB);
 		newTab.setAction(NEWTAB_OP_OPEN_TAB_MENU, OPEN_TAB_MENU);
+		newTab.setAction(NEWTAB_OP_FILTER_TAB_MENU, FILTER_TAB_MENU);
 		newTab.setOnOpListener((JavaScriptCallback) this::handleNewTab);
 
 		tabManager.clear();
@@ -489,6 +493,9 @@ public class TabInterface
 			case NEWTAB_OP_OPEN_TAB_MENU:
 				client.setVarbit(VarbitID.BANK_CURRENTTAB, 0);
 				plugin.openTag(TAGTABS, null, 0);
+				break;
+			case NEWTAB_OP_FILTER_TAB_MENU:
+				filterTagTabs();
 				break;
 		}
 	}
@@ -1145,6 +1152,7 @@ public class TabInterface
 		activeLayout = layout;
 		activeOptions = options;
 		tagTabActive = TAGTABS.equals(tag);
+		tagTabFilter = null;
 		config.tab(tag);
 
 		if (relayout)
@@ -1159,6 +1167,7 @@ public class TabInterface
 		activeLayout = null;
 		activeOptions = 0;
 		tagTabActive = false;
+		tagTabFilter = null;
 		plugin.openTag(null, null);
 		config.tab("");
 
@@ -1289,6 +1298,44 @@ public class TabInterface
 		}
 	}
 
+	private boolean matchesTagTabFilter(TagTab tagTab)
+	{
+		return Strings.isNullOrEmpty(tagTabFilter)
+			|| tagTab.getTag().toLowerCase().contains(tagTabFilter);
+	}
+
+	/**
+	 * Opens a prompt which filters the tag tab tab as it is typed into.
+	 */
+	public void filterTagTabs()
+	{
+		if (!tagTabActive)
+		{
+			client.setVarbit(VarbitID.BANK_CURRENTTAB, 0);
+			plugin.openTag(TAGTABS, null, 0);
+		}
+
+		chatboxPanelManager.openTextInput("Filter tag tabs:")
+			.value(Strings.nullToEmpty(tagTabFilter))
+			.onChanged(filter -> clientThread.invoke(() -> applyTagTabFilter(filter)))
+			.onDone((Consumer<String>) filter -> clientThread.invoke(() -> applyTagTabFilter(filter)))
+			.build();
+	}
+
+	private void applyTagTabFilter(String filter)
+	{
+		String trimmed = filter == null ? "" : filter.trim().toLowerCase();
+		if (trimmed.equals(Strings.nullToEmpty(tagTabFilter)))
+		{
+			return;
+		}
+
+		tagTabFilter = trimmed;
+		// layoutBank rather than reset: reset runs MESSAGE_LAYER_CLOSE, which closes the
+		// filter prompt the player is still typing into.
+		bankSearch.layoutBank();
+	}
+
 	private int rebuildTagTabTab()
 	{
 		int itemX = BANK_ITEM_START_X;
@@ -1319,6 +1366,11 @@ public class TabInterface
 		idx = tagTabFirstChildIdx;
 		for (TagTab tagTab : tabManager.getTabs())
 		{
+			if (!matchesTagTabFilter(tagTab))
+			{
+				continue;
+			}
+
 			Widget menu = parent.getChild(idx++);
 			if (menu == null)
 			{


### PR DESCRIPTION
The tag tab tab made a large number of tag tabs browsable, but it doesn't scale much past a few dozen — the grid becomes as slow to read as the tab strip is to scroll. This has come up repeatedly:

- #9625 asked for a way to find a tab without scrolling "3-4 at a time" with 20/30+ tabs, which the tag tab tab addressed.
- #10045 asked for folders, noting it had "become faster to just withdraw the items via normal navigation".
- #10963 asks for categories, and notes falling back on "using the bank search to access my tags, which is what the tab buttons are intended to avoid".

That last point is what this change follows: people already reach for search when the tabs stop scaling, so this puts search where they are already looking, rather than adding another organisational concept.

This adds a "Filter tag tabs" option to the new tab button, plus an optional keybind, which open a prompt that filters the tag tab tab as it is typed into. Tabs which do not match are skipped while the tab tab is rebuilt, so the remaining tabs repack and the scroll size is recomputed for them. The filter is cleared whenever a tag is opened or closed, so it cannot carry into a later visit.

The keybind defaults to unset rather than picking a combination, since Ctrl+F is taken by the bank search — happy to add a default if you would prefer one.

Relates to #9625, #10045 and #10963. It does not implement folders or categories, so it does not close #10963, but it addresses the underlying complaint with much less surface area.
