### PR TITLE
Improve Plugin Hub list rendering

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -52,7 +52,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -469,7 +468,7 @@ class PluginHubPanel extends PluginPanel
 	private final JLabel refreshing;
 	private final JPanel mainPanel;
 	private final JScrollPane scrollPane;
-	private final AtomicLong filterGeneration = new AtomicLong();
+	private long filterGeneration;
 	private List<PluginItem> plugins = null;
 	private List<PluginItem> filteredPlugins = Collections.emptyList();
 	private int renderedPluginCount;
@@ -515,19 +514,19 @@ class PluginHubPanel extends PluginPanel
 			@Override
 			public void insertUpdate(DocumentEvent e)
 			{
-				executor.execute(PluginHubPanel.this::filter);
+				filter();
 			}
 
 			@Override
 			public void removeUpdate(DocumentEvent e)
 			{
-				executor.execute(PluginHubPanel.this::filter);
+				filter();
 			}
 
 			@Override
 			public void changedUpdate(DocumentEvent e)
 			{
-				executor.execute(PluginHubPanel.this::filter);
+				filter();
 			}
 		});
 
@@ -617,7 +616,7 @@ class PluginHubPanel extends PluginPanel
 		filteredPlugins = Collections.emptyList();
 		renderedPluginCount = 0;
 		lastScrollValue = 0;
-		filterGeneration.incrementAndGet();
+		filterGeneration++;
 
 		executor.submit(() ->
 		{
@@ -690,52 +689,63 @@ class PluginHubPanel extends PluginPanel
 			}
 
 			refreshing.setVisible(false);
-			executor.execute(PluginHubPanel.this::filter);
+			filter();
 		});
 	}
 
 	void filter()
 	{
-		long generation = filterGeneration.incrementAndGet();
+		if (!SwingUtilities.isEventDispatchThread())
+		{
+			SwingUtilities.invokeLater(this::filter);
+			return;
+		}
+
+		long generation = ++filterGeneration;
 		if (refreshing.isVisible() || plugins == null)
 		{
 			return;
 		}
 
 		String query = searchBar.getText();
-		boolean isSearching = query != null && !query.trim().isEmpty();
-		List<PluginItem> pluginItems;
-		if (isSearching)
-		{
-			pluginItems = PluginSearch.search(plugins, query);
-		}
-		else
-		{
-			pluginItems = plugins.stream().filter(p -> p.isInstalled() || p.getJarData() != null)
-				.sorted(Comparator.comparing((PluginItem p) -> p.getJarData() == null)
-					.thenComparing(PluginItem::isInstalled)
-					.thenComparingInt(PluginItem::getUserCount)
-					.reversed()
-					.thenComparing(p -> p.manifest.getDisplayName())
-				)
-				.collect(Collectors.toList());
-		}
+		List<PluginItem> pluginSnapshot = plugins;
 
-		SwingUtilities.invokeLater(() ->
+		executor.execute(() ->
 		{
-			if (generation != filterGeneration.get())
+			boolean isSearching = query != null && !query.trim().isEmpty();
+			List<PluginItem> pluginItems;
+			if (isSearching)
 			{
-				return;
+				pluginItems = PluginSearch.search(pluginSnapshot, query);
+			}
+			else
+			{
+				pluginItems = pluginSnapshot.stream().filter(p -> p.isInstalled() || p.getJarData() != null)
+					.sorted(Comparator.comparing((PluginItem p) -> p.getJarData() == null)
+						.thenComparing(PluginItem::isInstalled)
+						.thenComparingInt(PluginItem::getUserCount)
+						.reversed()
+						.thenComparing(p -> p.manifest.getDisplayName())
+					)
+					.collect(Collectors.toList());
 			}
 
-			mainPanel.removeAll();
-			filteredPlugins = pluginItems;
-			renderedPluginCount = 0;
-			addPluginBatch(INITIAL_PLUGIN_COUNT);
-			scrollPane.getVerticalScrollBar().setValue(0);
-			lastScrollValue = 0;
-			mainPanel.revalidate();
-			mainPanel.repaint();
+			SwingUtilities.invokeLater(() ->
+			{
+				if (generation != filterGeneration)
+				{
+					return;
+				}
+
+				mainPanel.removeAll();
+				filteredPlugins = pluginItems;
+				renderedPluginCount = 0;
+				addPluginBatch(INITIAL_PLUGIN_COUNT);
+				scrollPane.getVerticalScrollBar().setValue(0);
+				lastScrollValue = 0;
+				mainPanel.revalidate();
+				mainPanel.repaint();
+			});
 		});
 	}
 
@@ -798,7 +808,7 @@ class PluginHubPanel extends PluginPanel
 		filteredPlugins = Collections.emptyList();
 		renderedPluginCount = 0;
 		lastScrollValue = 0;
-		filterGeneration.incrementAndGet();
+		filterGeneration++;
 		lastManifest = null;
 
 		synchronized (iconLoadQueue)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -35,6 +35,7 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.event.ActionEvent;
+import java.awt.event.AdjustmentEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -472,6 +473,7 @@ class PluginHubPanel extends PluginPanel
 	private List<PluginItem> plugins = null;
 	private List<PluginItem> filteredPlugins = Collections.emptyList();
 	private int renderedPluginCount;
+	private int lastScrollValue;
 	private PluginHubManifest.ManifestFull lastManifest;
 
 	@Inject
@@ -571,7 +573,7 @@ class PluginHubPanel extends PluginPanel
 		// Can't use Short.MAX_VALUE like the docs say because of JDK-8079640
 		scrollPane.setPreferredSize(new Dimension(0x7000, 0x7000));
 		scrollPane.setViewportView(mainPanelWrapper);
-		scrollPane.getVerticalScrollBar().addAdjustmentListener(e -> loadMorePluginsIfNeeded());
+		scrollPane.getVerticalScrollBar().addAdjustmentListener(this::onScroll);
 
 		{
 			GroupLayout layout = new GroupLayout(this);
@@ -614,6 +616,7 @@ class PluginHubPanel extends PluginPanel
 		mainPanel.removeAll();
 		filteredPlugins = Collections.emptyList();
 		renderedPluginCount = 0;
+		lastScrollValue = 0;
 		filterGeneration.incrementAndGet();
 
 		executor.submit(() ->
@@ -730,9 +733,23 @@ class PluginHubPanel extends PluginPanel
 			renderedPluginCount = 0;
 			addPluginBatch(INITIAL_PLUGIN_COUNT);
 			scrollPane.getVerticalScrollBar().setValue(0);
+			lastScrollValue = 0;
 			mainPanel.revalidate();
 			mainPanel.repaint();
 		});
+	}
+
+	private void onScroll(AdjustmentEvent event)
+	{
+		int scrollValue = event.getValue();
+		if (scrollValue <= lastScrollValue)
+		{
+			lastScrollValue = scrollValue;
+			return;
+		}
+
+		lastScrollValue = scrollValue;
+		loadMorePluginsIfNeeded();
 	}
 
 	private void loadMorePluginsIfNeeded()
@@ -780,6 +797,7 @@ class PluginHubPanel extends PluginPanel
 		plugins = null;
 		filteredPlugins = Collections.emptyList();
 		renderedPluginCount = 0;
+		lastScrollValue = 0;
 		filterGeneration.incrementAndGet();
 		lastManifest = null;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -103,6 +104,9 @@ class PluginHubPanel extends PluginPanel
 	private static final ImageIcon CONFIGURE_ICON;
 	private static final ImageIcon PLUGIN_UNAVAILABLE_ICON;
 	private static final Pattern SPACES = Pattern.compile(" +");
+	private static final int INITIAL_PLUGIN_COUNT = 40;
+	private static final int PLUGIN_PAGE_SIZE = 30;
+	private static final int SCROLL_BUFFER_ROWS = 10;
 
 	static
 	{
@@ -463,7 +467,11 @@ class PluginHubPanel extends PluginPanel
 	private final IconTextField searchBar;
 	private final JLabel refreshing;
 	private final JPanel mainPanel;
+	private final JScrollPane scrollPane;
+	private final AtomicLong filterGeneration = new AtomicLong();
 	private List<PluginItem> plugins = null;
+	private List<PluginItem> filteredPlugins = Collections.emptyList();
+	private int renderedPluginCount;
 	private PluginHubManifest.ManifestFull lastManifest;
 
 	@Inject
@@ -558,11 +566,12 @@ class PluginHubPanel extends PluginPanel
 				.addComponent(refreshing, 0, Short.MAX_VALUE, Short.MAX_VALUE));
 		}
 
-		JScrollPane scrollPane = new JScrollPane();
+		scrollPane = new JScrollPane();
 		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 		// Can't use Short.MAX_VALUE like the docs say because of JDK-8079640
 		scrollPane.setPreferredSize(new Dimension(0x7000, 0x7000));
 		scrollPane.setViewportView(mainPanelWrapper);
+		scrollPane.getVerticalScrollBar().addAdjustmentListener(e -> loadMorePluginsIfNeeded());
 
 		{
 			GroupLayout layout = new GroupLayout(this);
@@ -603,6 +612,9 @@ class PluginHubPanel extends PluginPanel
 
 		refreshing.setVisible(true);
 		mainPanel.removeAll();
+		filteredPlugins = Collections.emptyList();
+		renderedPluginCount = 0;
+		filterGeneration.incrementAndGet();
 
 		executor.submit(() ->
 		{
@@ -681,6 +693,7 @@ class PluginHubPanel extends PluginPanel
 
 	void filter()
 	{
+		long generation = filterGeneration.incrementAndGet();
 		if (refreshing.isVisible() || plugins == null)
 		{
 			return;
@@ -707,10 +720,47 @@ class PluginHubPanel extends PluginPanel
 
 		SwingUtilities.invokeLater(() ->
 		{
+			if (generation != filterGeneration.get())
+			{
+				return;
+			}
+
 			mainPanel.removeAll();
-			pluginItems.forEach(mainPanel::add);
+			filteredPlugins = pluginItems;
+			renderedPluginCount = 0;
+			addPluginBatch(INITIAL_PLUGIN_COUNT);
+			scrollPane.getVerticalScrollBar().setValue(0);
 			mainPanel.revalidate();
+			mainPanel.repaint();
 		});
+	}
+
+	private void loadMorePluginsIfNeeded()
+	{
+		if (refreshing.isVisible() || renderedPluginCount >= filteredPlugins.size())
+		{
+			return;
+		}
+
+		int remainingPixels = scrollPane.getVerticalScrollBar().getMaximum()
+			- scrollPane.getVerticalScrollBar().getVisibleAmount()
+			- scrollPane.getVerticalScrollBar().getValue();
+		if (remainingPixels <= PluginItem.HEIGHT * SCROLL_BUFFER_ROWS)
+		{
+			addPluginBatch(PLUGIN_PAGE_SIZE);
+			mainPanel.revalidate();
+			mainPanel.repaint();
+		}
+	}
+
+	private void addPluginBatch(int count)
+	{
+		int end = Math.min(renderedPluginCount + count, filteredPlugins.size());
+		for (int i = renderedPluginCount; i < end; i++)
+		{
+			mainPanel.add(filteredPlugins.get(i));
+		}
+		renderedPluginCount = end;
 	}
 
 	@Override
@@ -728,6 +778,9 @@ class PluginHubPanel extends PluginPanel
 		mainPanel.removeAll();
 		refreshing.setVisible(false);
 		plugins = null;
+		filteredPlugins = Collections.emptyList();
+		renderedPluginCount = 0;
+		filterGeneration.incrementAndGet();
 		lastManifest = null;
 
 		synchronized (iconLoadQueue)


### PR DESCRIPTION
## Summary
- render an initial buffered batch of Plugin Hub results
- append additional batches as the user approaches the end of the list
- prevent stale asynchronous filters from replacing newer search results
- reset pagination state during refresh and deactivation

## Testing
- `./gradlew.bat :client:compileJava`
- `./gradlew.bat :client:checkstyleMain`