### PR TITLE
clues: add item requirements overlay to cryptic clues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -57,6 +57,13 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 
+import net.runelite.api.Client;
+import net.runelite.api.Item;
+import net.runelite.client.plugins.cluescrolls.clues.item.ItemRequirement;
+import static net.runelite.client.plugins.cluescrolls.clues.item.ItemRequirements.item;
+import net.runelite.client.ui.FontManager;
+import static net.runelite.client.plugins.cluescrolls.clues.item.ItemRequirements.any;
+
 @Getter
 @Slf4j
 @ToString
@@ -591,6 +598,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 			.location(new WorldPoint(3289, 3022, 0))
 			.objectId(ObjectID.TOURTRAP_QIP_CRATE_SINGLE)
 			.solution("Center of desert Mining Camp. Search the crates. Requires the metal key from Tourist Trap to enter.")
+			.itemRequirement(item(ItemID.METAL_KEY))
 			.build(),
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_HARD_RIDDLE_EXP7)
@@ -658,6 +666,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 			.npcRegion(13457)
 			.solution("Enter the crack west of Nardah Rug merchant, and talk to the Genie. You'll need a light source and a rope.")
 			.requiresLight(true)
+			.itemRequirement(item(ItemID.ROPE))
 			.build(),
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_CLUE_HARD_RIDDLE010)
@@ -669,7 +678,8 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 			.itemId(ItemID.TRAIL_ELITE_RIDDLE_EXP2)
 			.text("Green is the colour of my death as the winter-guise, I swoop towards the ground.")
 			.location(new WorldPoint(2780, 3783, 0))
-			.solution("Slide down to where Trollweiss grows on Trollweiss Mountain. Bring a sled.")
+			.solution("Slide down to where Trollweiss grows on Trollweiss Mountain.")
+			.itemRequirement(item(ItemID.TROLLROMANCE_TOBOGGON_WAXED))
 			.build(),
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_EASY_VAGUE_EXP4)
@@ -1550,6 +1560,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 			.text("2 musical birds. Dig in front of the spinning light.")
 			.location(new WorldPoint(2671, 10396, 0))
 			.solution("Dig in front of the spinning light in Ping and Pong's room inside the Iceberg")
+			.itemRequirement(any("Clockwork suit", item(ItemID.PENG_SUIT_UNWOUND), item(ItemID.PENG_SUIT_WOUND)))
 			.build(),
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_EASY_SIMPLE_EXP9)
@@ -1681,6 +1692,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 			.location(new WorldPoint(2723, 9891, 0))
 			.objectId(ObjectID.ELEM_CRATE_1)
 			.solution("Search the crate, west of the Air Elementals, inside the Elemental Workshop.")
+			.itemRequirement(item(ItemID.ELEMENTAL_WORKSHOP_KEY))
 			.build(),
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_ELITE_RIDDLE_EXP22)
@@ -2048,6 +2060,9 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 
 	private static final int DEFAULT_RESOURCE_AREA_COST = 7500;
 
+	private static final String UNICODE_CHECK_MARK = "\u2713";
+	private static final String UNICODE_BALLOT_X = "\u2717";
+
 	private final Set<Integer> itemIds;
 	private final String text;
 	@Nullable
@@ -2066,6 +2081,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 	@Nullable
 	private final String answer;
 	private final List<Integer> npcRegions;
+	private final List<ItemRequirement> itemRequirements;
 
 	@Builder
 	private CrypticClue(
@@ -2082,7 +2098,8 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		@Nullable String questionText,
 		@Nullable String answer,
 		boolean requiresLight,
-		@Singular List<Integer> npcRegions
+		@Singular List<Integer> npcRegions,
+		@Singular List<ItemRequirement> itemRequirements
 	)
 	{
 		this.itemIds = itemIds != null ? itemIds : (itemId != null ? Set.of(itemId) : Set.of(-1));
@@ -2095,6 +2112,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		this.questionText = questionText;
 		this.answer = answer;
 		this.npcRegions = npcRegions;
+		this.itemRequirements = itemRequirements;
 		setRequiresSpade(this.locationProvider != null && this.npcProvider == null && this.objectId == -1);
 		setRequiresLight(requiresLight);
 	}
@@ -2164,6 +2182,44 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 				.left(getAnswer())
 				.leftColor(TITLED_CONTENT_COLOR)
 				.build());
+		}
+
+		if (!itemRequirements.isEmpty())
+		{
+			final Client client = plugin.getClient();
+
+			Item[] equipment = plugin.getEquippedItems();
+			Item[] inventory = plugin.getInventoryItems();
+
+			if (equipment == null)
+			{
+				equipment = new Item[0];
+			}
+
+			if (inventory == null)
+			{
+				inventory = new Item[0];
+			}
+
+			final Item[] combined = new Item[equipment.length + inventory.length];
+			System.arraycopy(equipment, 0, combined, 0, equipment.length);
+			System.arraycopy(inventory, 0, combined, equipment.length, inventory.length);
+
+			panelComponent.getChildren().add(LineComponent.builder().left("").build());
+			panelComponent.getChildren().add(LineComponent.builder().left("Bring:").build());
+
+			for (ItemRequirement requirement : itemRequirements)
+			{
+				final boolean fulfilled = requirement.fulfilledBy(combined);
+
+				panelComponent.getChildren().add(LineComponent.builder()
+						.left(requirement.getCollectiveName(client))
+						.leftColor(TITLED_CONTENT_COLOR)
+						.right(fulfilled ? UNICODE_CHECK_MARK : UNICODE_BALLOT_X)
+						.rightFont(FontManager.getDefaultFont())
+						.rightColor(fulfilled ? Color.GREEN : Color.RED)
+						.build());
+			}
 		}
 
 		renderOverlayNote(panelComponent, plugin);


### PR DESCRIPTION
Fixes #20362 

## Problem

Cryptic clues that require items don't surface those requirements in the overlay. The Nardah genie step is the reported case: its solution text says a light source and a rope are needed, but only "Requires Light Source!" appears. A player reading the overlay has no indication the rope is missing.

## Cause

`CrypticClue` has no mechanism for declaring item requirements. The only requirements displayed are `requiresLight` and `requiresSpade`, both booleans fromthe `ClueScroll` base class. There is no general item requirement support, so this is a missing feature rather than a bug or missing data on the specific Nardah clue step.

`EmoteClue` already solves this: it takes `ItemRequirement` values and renders fulfilment in its own `makeOverlayHint`.

## Fix

Add a `@Singular List<ItemRequirement> itemRequirements` to the `CrypticClue` builder and render unmet requirements in `CrypticClue.makeOverlayHint`, following the pattern in `EmoteClue`. Requirements are checked against inventory and equipment combined. Requirements fulfilled by interchangeable items use `any(...)` like in `EmoteClue`.

Requirements are populated for five clue steps:
- Nardah genie step (issue opened on this clue)
- Elemental Workshop (battered key required)
- Iceberg (clockwork suit required)
- Trollweiss Mountain (sled required)
- Desert mining camp (metal key required)

## Screenshots

These screenshots show the difference from the original clue overlay to the new one with the item missing from the player's inventory and the new overlay when the player has the item required.

Nardah genie step:
<img width="183" height="308" alt="genieStepOld" src="https://github.com/user-attachments/assets/006ade74-cb48-463f-8e7b-1bc69b296978" /><img width="185" height="386" alt="genieRopeNone" src="https://github.com/user-attachments/assets/e4166a9c-ed63-4b35-913b-bcdecce53407" /><img width="187" height="381" alt="genieRopeYes" src="https://github.com/user-attachments/assets/9e176bf7-cbfe-4518-b1eb-5c43ffe8b205" />

Elemental Workshop step - no mention of battered key in old plugin:
<img width="186" height="218" alt="batteredKeyOld" src="https://github.com/user-attachments/assets/5d4001ad-b790-4d25-bf18-55dcc2dab159" /><img width="187" height="293" alt="batteredKeyClean" src="https://github.com/user-attachments/assets/f4a54932-7f98-4de8-a66d-5a1804c94140" /><img width="186" height="292" alt="batteredKeyFulfilled" src="https://github.com/user-attachments/assets/e8c210bc-e797-46e5-a449-62374be796a0" />

Iceberg step - no mention of clockwork suit in old plugin:
<img width="185" height="147" alt="pengSuitOld" src="https://github.com/user-attachments/assets/aef85bc1-11ca-47d9-8989-d23b8ade8838" /><img width="186" height="225" alt="penSuitClean" src="https://github.com/user-attachments/assets/539499c2-73f3-47cb-ab23-5361cc7225d7" /><img width="183" height="225" alt="pengSuitFulfilled" src="https://github.com/user-attachments/assets/5ac76301-fab7-40fa-9703-16ec8c655a8b" />

Trollweiss Mountain Step:
<img width="210" height="164" alt="oldSledClue" src="https://github.com/user-attachments/assets/31b1ae39-ce04-4927-a6e1-8561fc277343" /><img width="200" height="212" alt="newSledClueMissing" src="https://github.com/user-attachments/assets/8942b228-d64d-4d54-86df-911362f9e731" /><img width="196" height="214" alt="newSledClue" src="https://github.com/user-attachments/assets/98d5426b-a801-4131-929b-3ce89f92cabc" />

Desert Mining camp step:
<img width="184" height="216" alt="metalKeyOld" src="https://github.com/user-attachments/assets/49a145dd-46bc-46aa-b538-076486ea7690" /><img width="191" height="303" alt="metalKeyMissing" src="https://github.com/user-attachments/assets/e041d839-44cd-4b23-837d-38aff1aad3ff" /><img width="184" height="292" alt="metalKeyFulfilled" src="https://github.com/user-attachments/assets/6f8a9a8a-8c33-4af9-aa81-efe1ddb7029b" />

## Testing
- [x] Requirement shows red when the item is missing, green when in inventory or equipped
- [x] The existing "Requires Light Source!" and "Requires Spade!" lines still render with no duplication
- [x] Clues without item requirements render unchanged
- [x] All five populated clue steps verified individually
- [x] Item requirements fulfilled by interchangeable items are correctly satisfied

## Scope

The only clues I added this feature for so far are these five. Certain cryptic clues have item requirements but I felt that for now they were too bulky to add to the overlay. For example, the Viyeldi caves step has multiple item requirements and they differ based on the player's agility level. The overlay would become bulky and for a step like this, the player likely reads the overlay closely. I wanted to focus on steps where they likely go straight to the map to see where they need to go and the overlay will help them remember a small item they may miss just glancing at the overlay popup. Item requirements can easily be added to any step desired by just populating the given step in `CrypticClue`.

## Known Limitation

Steps requiring a key that is stored on the key ring is currently not detected. Key ring contents don't appear in varbits, varps, or item containers, so `fulfilledBy` can't see them. A key on the ring would incorrectly show as missing. If anyone has a better understanding of how to detect keys on the keyrings, it would be a good addition to add!