### PR TITLE
gpu: fix ui scaling targetDimensions in stretched mode

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -1562,17 +1562,18 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		);
 		glUniform1f(uniUiColorblindIntensity, config.colorBlindIntensity());
 
+		final GraphicsConfiguration graphicsConfiguration = clientUI.getGraphicsConfiguration();
+		final AffineTransform t = graphicsConfiguration.getDefaultTransform();
+
 		if (client.isStretchedEnabled())
 		{
 			Dimension dim = client.getStretchedDimensions();
 			glDpiAwareViewport(0, 0, dim.width, dim.height);
-			glUniform2i(uniTexTargetDimensions, dim.width, dim.height);
+			glUniform2i(uniTexTargetDimensions, getScaledValue(t.getScaleX(), dim.width), getScaledValue(t.getScaleY(), dim.height));
 		}
 		else
 		{
 			glDpiAwareViewport(0, 0, canvasWidth, canvasHeight);
-			final GraphicsConfiguration graphicsConfiguration = clientUI.getGraphicsConfiguration();
-			final AffineTransform t = graphicsConfiguration.getDefaultTransform();
 			glUniform2i(uniTexTargetDimensions, getScaledValue(t.getScaleX(), canvasWidth), getScaledValue(t.getScaleY(), canvasHeight));
 		}
 


### PR DESCRIPTION
Currently, `GpuPlugin.drawUi` does not properly apply display scaling if stretching is enabled, as `glUniform2i` is given raw dimensions rather than dpi aware dimensions. This causes UI scaling on a 4k monitor using OS scaling, such as "2560x1440" (or More Space) on macOS, or 150% scaling on Windows, to look significantly worse, most noticeably on the 'Hybrid' UI scaling mode.

5d05fbb17 fixed this previously for the case when `client.isStretchedEnabled()` is false. This PR is to apply the same fix to the case where `client.isStretchedEnabled()` is true, which has been unscaled since targetDimensions was introduced in 66fac018e.

Before:
<img width="624" height="38" alt="CleanShot 2026-08-21 at 21 40 53@2x" src="https://github.com/user-attachments/assets/6cfe1e5e-8173-4f37-9d4e-52fe879bd584" />


After:
<img width="588" height="38" alt="CleanShot 2026-08-21 at 21 38 28@2x" src="https://github.com/user-attachments/assets/e3eb4749-1b87-41eb-898f-a18f7ddbb78c" />
