### PR TITLE
BankTags LayoutManager: add quiver's ammo to layout & ammo plugin update

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ParamID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ParamID.java
@@ -234,4 +234,6 @@ public final class ParamID
 	public static final int BANK_AUTOCHARGE = 2257;
 
 	public static final int CLUE_SCROLL = 623;
+
+	public static final int QUIVER_AMMO_AVAILABLE = 1910;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoPlugin.java
@@ -24,24 +24,21 @@
  */
 package net.runelite.client.plugins.ammo;
 
-import com.google.common.collect.ImmutableSet;
 import java.awt.image.BufferedImage;
-import java.util.Set;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.Item;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.ParamID;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.gameval.InventoryID;
-import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
-import net.runelite.client.game.ItemVariationMapping;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
@@ -54,12 +51,6 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 )
 public class AmmoPlugin extends Plugin
 {
-	private static final Set<Integer> DIZANAS_QUIVER_IDS = ImmutableSet.<Integer>builder()
-		.addAll(ItemVariationMapping.getVariations(ItemVariationMapping.map(ItemID.DIZANAS_QUIVER_CHARGED)))
-		.addAll(ItemVariationMapping.getVariations(ItemVariationMapping.map(ItemID.DIZANAS_QUIVER_INFINITE)))
-		.addAll(ItemVariationMapping.getVariations(ItemVariationMapping.map(ItemID.SKILLCAPE_MAX_DIZANAS)))
-		.build();
-
 	@Inject
 	private Client client;
 
@@ -122,7 +113,7 @@ public class AmmoPlugin extends Plugin
 	private void checkInventory(ItemContainer equipment)
 	{
 		final Item cape = equipment.getItem(EquipmentInventorySlot.CAPE.getSlotIdx());
-		isWearingQuiver = cape != null && DIZANAS_QUIVER_IDS.contains(cape.getId());
+		isWearingQuiver = cape != null && itemManager.getItemComposition(cape.getId()).getIntValue(ParamID.QUIVER_AMMO_AVAILABLE) == 1;
 		checkQuiver();
 
 		// Check for weapon slot items. This overrides the ammo slot,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java
@@ -26,6 +26,7 @@
 package net.runelite.client.plugins.banktags.tabs;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -59,6 +60,7 @@ import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarClientID;
+import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.api.widgets.ItemQuantityMode;
 import net.runelite.api.widgets.JavaScriptCallback;
@@ -880,6 +882,13 @@ public class LayoutManager
 				}
 			}
 
+			// quiver
+			if (hasQuiver(i, e))
+			{
+				final int quiverAmmo = client.getVarpValue(VarPlayerID.DIZANAS_QUIVER_TEMP_AMMO);
+				l.setItemAtPos(quiverAmmo, 2);
+			}
+
 			// Middle column
 			for (int j = 0; j < 5; ++j)
 			{
@@ -914,6 +923,14 @@ public class LayoutManager
 			Collection<Integer> runePouchVariations = ItemVariationMapping.getVariations(ItemID.BH_RUNE_POUCH);
 			Collection<Integer> divineRunePouchVariations = ItemVariationMapping.getVariations(ItemID.DIVINE_RUNE_POUCH);
 			return runePouchVariations.stream().anyMatch(inv::contains) || divineRunePouchVariations.stream().anyMatch(inv::contains);
+		}
+
+		private boolean hasQuiver(ItemContainer inv, ItemContainer worn)
+		{
+			final Item cape = worn != null ? worn.getItem(EquipmentInventorySlot.CAPE.getSlotIdx()) : null;
+
+			return (cape != null && client.getItemDefinition(cape.getId()).getIntValue(ParamID.QUIVER_AMMO_AVAILABLE) == 1)
+				|| (inv != null && Arrays.stream(inv.getItems()).anyMatch(item -> client.getItemDefinition(item.getId()).getIntValue(ParamID.QUIVER_AMMO_AVAILABLE) == 1));
 		}
 	}
 }


### PR DESCRIPTION
If quiver is in worn or in inventory place the ammo found within the quiver into spot 2 within the Default layouting. 

<img width="188" height="192" alt="image" src="https://github.com/user-attachments/assets/9947dee1-ab99-4912-85b9-bc79d2060fed" />
