### PR TITLE
enhances @Range so it can be used with doubles and Dimensions, and adds @Step

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigItemDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigItemDescriptor.java
@@ -35,6 +35,7 @@ public class ConfigItemDescriptor implements ConfigObject
 	private final Range range;
 	private final Alpha alpha;
 	private final Units units;
+	private final Step step;
 
 	@Override
 	public String key()

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -1062,7 +1062,8 @@ public class ConfigManager
 				m.getGenericReturnType(),
 				m.getDeclaredAnnotation(Range.class),
 				m.getDeclaredAnnotation(Alpha.class),
-				m.getDeclaredAnnotation(Units.class)
+				m.getDeclaredAnnotation(Units.class),
+				m.getDeclaredAnnotation(Step.class)
 			))
 			.sorted((a, b) -> ComparisonChain.start()
 				.compare(a.getItem().position(), b.getItem().position())

--- a/runelite-client/src/main/java/net/runelite/client/config/Range.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/Range.java
@@ -31,7 +31,21 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used with ConfigItem, describes valid int range for a config item.
+ * <p>
+ * Used with {@link ConfigItem}, describes valid range for a numeric config item.
+ * </p>
+ * <ul>
+ *     <li>for an {@code int} item, use {@link #min()} and {@link #max()}</li>
+ *     <li>for a {@code double} item, use {@link #minDouble()} and {@link #maxDouble()}</li>
+ *     <li>for a {@link java.awt.Dimension} item, use:
+ *     <ul>
+ *         <li>{@link #min()} and {@link #max()} for the {@link java.awt.Dimension#width}</li>
+ *         <li>{@link #minHeight()} and {@link #maxHeight()} for the {@link java.awt.Dimension#height}</li>
+ *     </ul>
+ * </ul>
+ * <p>
+ * Any values specified other than those described above will be ignored.
+ * </p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
@@ -41,4 +55,12 @@ public @interface Range
 	int min() default 0;
 
 	int max() default Integer.MAX_VALUE;
+
+	int minHeight() default 0;
+
+	int maxHeight() default Integer.MAX_VALUE;
+
+	double minDouble() default 0.0;
+
+	double maxDouble() default Double.MAX_VALUE;
 }

--- a/runelite-client/src/main/java/net/runelite/client/config/Step.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/Step.java
@@ -1,0 +1,36 @@
+package net.runelite.client.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * Used with {@link ConfigItem}, describes the step size for a numeric config item.
+ * </p>
+ * <ul>
+ *     <li>for an {@code int} item, use {@link #step()}</li>
+ *     <li>for a {@code double} item, use {@link #stepDouble()}</li>
+ *     <li>for a {@link java.awt.Dimension} item, use:
+ *     <ul>
+ *         <li>{@link #step()} {@link java.awt.Dimension#width}</li>
+ *         <li>{@link #stepHeight()} for the {@link java.awt.Dimension#height}</li>
+ *     </ul>
+ * </ul>
+ * <p>
+ * Any values specified other than those described above will be ignored.
+ * </p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Documented
+public @interface Step
+{
+	int step() default 1;
+
+	int stepHeight() default 1;
+
+	double stepDouble() default 0.1;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -28,6 +28,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Ints;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -88,6 +89,7 @@ import net.runelite.client.config.Keybind;
 import net.runelite.client.config.ModifierlessKeybind;
 import net.runelite.client.config.Notification;
 import net.runelite.client.config.Range;
+import net.runelite.client.config.Step;
 import net.runelite.client.config.Units;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ExternalPluginsChanged;
@@ -463,7 +465,7 @@ class ConfigPanel extends PluginPanel
 		int value = MoreObjects.firstNonNull(configManager.getConfiguration(cd.getGroup().value(), cid.getItem().keyName(), int.class), 0);
 
 		Range range = cid.getRange();
-		int min = 0, max = Integer.MAX_VALUE;
+		int min = 0, max = Integer.MAX_VALUE, stepSize = 1;
 		if (range != null)
 		{
 			min = range.min();
@@ -473,7 +475,13 @@ class ConfigPanel extends PluginPanel
 		// Config may previously have been out of range
 		value = Ints.constrainToRange(value, min, max);
 
-		SpinnerModel model = new SpinnerNumberModel(value, min, max, 1);
+		Step step = cid.getStep();
+		if (step != null)
+		{
+			stepSize = step.step();
+		}
+
+		SpinnerModel model = new SpinnerNumberModel(value, min, max, stepSize);
 		JSpinner spinner = new JSpinner(model);
 		Component editor = spinner.getEditor();
 		JFormattedTextField spinnerTextField = ((JSpinner.DefaultEditor) editor).getTextField();
@@ -495,7 +503,24 @@ class ConfigPanel extends PluginPanel
 	{
 		double value = MoreObjects.firstNonNull(configManager.getConfiguration(cd.getGroup().value(), cid.getItem().keyName(), double.class), 0d);
 
-		SpinnerModel model = new SpinnerNumberModel(value, 0, Double.MAX_VALUE, 0.1);
+		Range range = cid.getRange();
+		double min = 0, max = Double.MAX_VALUE, stepSize = 0.1;
+		if (range != null)
+		{
+			min = range.minDouble();
+			max = range.maxDouble();
+		}
+
+		// Config may previously have been out of range
+		value = Doubles.constrainToRange(value, min, max);
+
+		Step step = cid.getStep();
+		if (step != null)
+		{
+			stepSize = step.stepDouble();
+		}
+
+		SpinnerModel model = new SpinnerNumberModel(value, min, max, stepSize);
 		JSpinner spinner = new JSpinner(model);
 		Component editor = spinner.getEditor();
 		JFormattedTextField spinnerTextField = ((JSpinner.DefaultEditor) editor).getTextField();
@@ -596,13 +621,34 @@ class ConfigPanel extends PluginPanel
 		int width = dimension.width;
 		int height = dimension.height;
 
-		SpinnerModel widthModel = new SpinnerNumberModel(width, 0, Integer.MAX_VALUE, 1);
+		Range range = cid.getRange();
+		int minX = 0, maxX = Integer.MAX_VALUE, minY = 0, maxY = Integer.MAX_VALUE, stepSizeX = 1, stepSizeY = 1;
+		if (range != null)
+		{
+			minX = range.min();
+			maxX = range.max();
+			minY = range.minHeight();
+			maxY = range.maxHeight();
+		}
+
+		// Config may previously have been out of range
+		width = Ints.constrainToRange(width, minX, maxX);
+		height = Ints.constrainToRange(height, minY, maxY);
+
+		Step step = cid.getStep();
+		if (step != null)
+		{
+			stepSizeX = step.step();
+			stepSizeY = step.stepHeight();
+		}
+
+		SpinnerModel widthModel = new SpinnerNumberModel(width, minX, maxX, stepSizeX);
 		JSpinner widthSpinner = new JSpinner(widthModel);
 		Component widthEditor = widthSpinner.getEditor();
 		JFormattedTextField widthSpinnerTextField = ((JSpinner.DefaultEditor) widthEditor).getTextField();
 		widthSpinnerTextField.setColumns(4);
 
-		SpinnerModel heightModel = new SpinnerNumberModel(height, 0, Integer.MAX_VALUE, 1);
+		SpinnerModel heightModel = new SpinnerNumberModel(height, minY, maxY, stepSizeY);
 		JSpinner heightSpinner = new JSpinner(heightModel);
 		Component heightEditor = heightSpinner.getEditor();
 		JFormattedTextField heightSpinnerTextField = ((JSpinner.DefaultEditor) heightEditor).getTextField();


### PR DESCRIPTION
This isn't a huge change, just gives a bit more control on configuration for both bundled plugins to use and Hub plugins. I've taken care to ensure it is backwards compatible (only additive, no breaking API changes) and doesn't change default behaviour.

## `@Range`

Currently, only works on a config item that is an `int` type. 

This enhances it so it can also be used for a `double` (via the new `minDouble` / `maxDouble`) and a `Dimension` (interpretting the existing `min` / `max` as relating to `width`, and the new `minHeight` / `maxHeight` for `height`).

The change is additive & backwards compatible, so plugins already using this annotation won't need to be adjusted, this just gives it some more places where it can be used.

Note the default values correspond to what is currently in place, so there should be no behaviour change by default.

## `@Step`

Adds a new annotation, `@Step` that can be used to define the step size of a spinner config item. I initially thought this could be useful with my (unrelated) pull request to add icon scaling #20438. Scaling up/down by 1% isn't super useful, would be nice if the buttons could have a step size of, say 10%.

Similarly to the update for `@Range`, this can be done on an `int`, `double`, or `Dimension` config item, and if not specified the default behaviour matches the existing behaviour.