### PR TITLE
ground items: add configurable item icons

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -46,14 +46,12 @@ public interface GroundItemsConfig extends Config
 {
 	String GROUP = "grounditems";
 	String OWNERSHIP_FILTER_MODE = "ownershipFilterMode";
-
 	@ConfigSection(
 		name = "Item lists",
 		description = "The highlighted and hidden item lists.",
 		position = 0
 	)
 	String itemLists = "itemLists";
-
 	@ConfigItem(
 		keyName = "highlightedItems",
 		name = "Highlighted items",
@@ -65,14 +63,12 @@ public interface GroundItemsConfig extends Config
 	{
 		return "";
 	}
-
 	@ConfigItem(
 		keyName = "highlightedItems",
 		name = "",
 		description = ""
 	)
 	void setHighlightedItem(String key);
-
 	@ConfigItem(
 		keyName = "hiddenItems",
 		name = "Hidden items",
@@ -84,14 +80,12 @@ public interface GroundItemsConfig extends Config
 	{
 		return "Vial, Ashes, Coins, Bones, Bucket, Jug, Seaweed";
 	}
-
 	@ConfigItem(
 		keyName = "hiddenItems",
 		name = "",
 		description = ""
 	)
 	void setHiddenItems(String key);
-
 	@ConfigItem(
 		keyName = "showHighlightedOnly",
 		name = "Show highlighted items only",
@@ -102,7 +96,6 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
-
 	@ConfigItem(
 		keyName = "dontHideUntradeables",
 		name = "Do not hide untradeables",
@@ -113,7 +106,6 @@ public interface GroundItemsConfig extends Config
 	{
 		return true;
 	}
-
 	@ConfigItem(
 		keyName = "showMenuItemQuantities",
 		name = "Show menu item quantities",
@@ -124,7 +116,6 @@ public interface GroundItemsConfig extends Config
 	{
 		return true;
 	}
-
 	@ConfigItem(
 		keyName = "recolorMenuHiddenItems",
 		name = "Recolor menu hidden items",
@@ -135,7 +126,6 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
-
 	@ConfigItem(
 		keyName = "deprioritizeHiddenItems",
 		name = "Deprioritize menu hidden items",
@@ -146,7 +136,6 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
-
 	@ConfigItem(
 		keyName = "highlightTiles",
 		name = "Highlight tiles",
@@ -157,7 +146,6 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
-
 	@ConfigItem(
 		keyName = "notifyHighlightedDrops",
 		name = "Notify for highlighted drops",
@@ -168,295 +156,289 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
-
+	@ConfigItem(
+		keyName = "showItemIcons",
+		name = "Show item icons",
+		description = "Display the item icon next to ground item names.",
+		position = 8
+	)
+	default boolean showItemIcons()
+	{
+		return false;
+	}
+	@ConfigItem(
+		keyName = "iconSize",
+		name = "Item icon size",
+		description = "Size of ground item icons in pixels.",
+		position = 9
+	)
+	default int iconSize()
+	{
+		return 16;
+	}
 	@ConfigItem(
 		keyName = "notifyTier",
 		name = "Notify tier",
 		description = "Configures which price tiers will trigger a notification on drop.",
-		position = 8
+		position = 10
 	)
 	default HighlightTier notifyTier()
 	{
 		return HighlightTier.OFF;
 	}
-
 	@ConfigItem(
 		keyName = "priceDisplayMode",
 		name = "Price display mode",
 		description = "Configures which price types are shown alongside ground item name.",
-		position = 9
+		position = 11
 	)
 	default PriceDisplayMode priceDisplayMode()
 	{
 		return PriceDisplayMode.BOTH;
 	}
-
 	@ConfigItem(
 		keyName = "itemHighlightMode",
 		name = "Item highlight mode",
 		description = "Configures how ground items will be highlighted.",
-		position = 10
+		position = 12
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
 		return ItemHighlightMode.BOTH;
 	}
-
 	@ConfigItem(
 		keyName = "menuHighlightMode",
 		name = "Menu highlight mode",
 		description = "Configures what to highlight in right-click menu.",
-		position = 11
+		position = 13
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
 		return MenuHighlightMode.NAME;
 	}
-
 	@ConfigItem(
 		keyName = "highlightValueCalculation",
 		name = "Highlight value calculation",
 		description = "Configures which coin value is used to determine highlight color.",
-		position = 12
+		position = 14
 	)
 	default ValueCalculationMode valueCalculationMode()
 	{
 		return ValueCalculationMode.HIGHEST;
 	}
-
 	@ConfigItem(
 		keyName = "hideUnderValue",
 		name = "Hide under value",
 		description = "Configures hidden ground items under both GE and HA value.",
-		position = 13
+		position = 15
 	)
 	default int getHideUnderValue()
 	{
 		return 0;
 	}
-
 	@Alpha
 	@ConfigItem(
 		keyName = "defaultColor",
 		name = "Default items",
 		description = "Configures the color for default, non-highlighted items.",
-		position = 14
+		position = 16
 	)
 	default Color defaultColor()
 	{
 		return Color.WHITE;
 	}
-
 	@Alpha
 	@ConfigItem(
 		keyName = "highlightedColor",
 		name = "Highlighted items",
 		description = "Configures the color for highlighted items.",
-		position = 15
+		position = 17
 	)
 	default Color highlightedColor()
 	{
 		return Color.decode("#AA00FF");
 	}
-
 	@Alpha
 	@ConfigItem(
 		keyName = "hiddenColor",
 		name = "Hidden items",
 		description = "Configures the color for hidden items in right-click menu and when holding ALT.",
-		position = 16
+		position = 18
 	)
 	default Color hiddenColor()
 	{
 		return Color.GRAY;
 	}
-
 	@Alpha
 	@ConfigItem(
 		keyName = "lowValueColor",
 		name = "Low value items",
 		description = "Configures the color for low value items.",
-		position = 17
+		position = 19
 	)
 	default Color lowValueColor()
 	{
 		return Color.decode("#66B2FF");
 	}
-
 	@ConfigItem(
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items.",
-		position = 18
+		position = 20
 	)
 	default int lowValuePrice()
 	{
 		return 20000;
 	}
-
 	@Alpha
 	@ConfigItem(
 		keyName = "mediumValueColor",
 		name = "Medium value items",
 		description = "Configures the color for medium value items.",
-		position = 19
+		position = 21
 	)
 	default Color mediumValueColor()
 	{
 		return Color.decode("#99FF99");
 	}
-
 	@ConfigItem(
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items.",
-		position = 20
+		position = 22
 	)
 	default int mediumValuePrice()
 	{
 		return 100000;
 	}
-
 	@Alpha
 	@ConfigItem(
 		keyName = "highValueColor",
 		name = "High value items",
 		description = "Configures the color for high value items.",
-		position = 21
+		position = 23
 	)
 	default Color highValueColor()
 	{
 		return Color.decode("#FF9600");
 	}
-
 	@ConfigItem(
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items.",
-		position = 22
+		position = 24
 	)
 	default int highValuePrice()
 	{
 		return 1000000;
 	}
-
 	@Alpha
 	@ConfigItem(
 		keyName = "insaneValueColor",
 		name = "Insane value items",
 		description = "Configures the color for insane value items.",
-		position = 23
+		position = 25
 	)
 	default Color insaneValueColor()
 	{
 		return Color.decode("#FF66B2");
 	}
-
 	@ConfigItem(
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items.",
-		position = 24
+		position = 26
 	)
 	default int insaneValuePrice()
 	{
 		return 10000000;
 	}
-
 	@ConfigItem(
 		keyName = OWNERSHIP_FILTER_MODE,
 		name = "Ownership filter",
 		description = "Show all items, takeable items, or only your or your group's drops.",
-		position = 25
+		position = 27
 	)
 	default OwnershipFilterMode ownershipFilterMode()
 	{
 		return OwnershipFilterMode.ALL;
 	}
-
 	@ConfigItem(
 		keyName = "doubleTapDelay",
 		name = "Double-tap delay",
 		description = "Delay for the double-tap ALT to hide ground items. 0 to disable.",
-		position = 26
+		position = 28
 	)
 	@Units(Units.MILLISECONDS)
 	default int doubleTapDelay()
 	{
 		return 250;
 	}
-
 	@ConfigItem(
 		keyName = "collapseEntries",
 		name = "Collapse ground item menu",
 		description = "Collapses ground item menu entries together and appends count.",
-		position = 27
+		position = 29
 	)
 	default boolean collapseEntries()
 	{
 		return false;
 	}
-
 	@ConfigItem(
 		keyName = "groundItemTimers",
 		name = "Despawn timer",
 		description = "Shows despawn timers for items you've dropped and received as loot.",
-		position = 28
+		position = 30
 	)
 	default DespawnTimerMode groundItemTimers()
 	{
 		return DespawnTimerMode.OFF;
 	}
-
 	@ConfigItem(
 		keyName = "textOutline",
 		name = "Text outline",
 		description = "Use an outline around text instead of a text shadow.",
-		position = 29
+		position = 31
 	)
 	default boolean textOutline()
 	{
 		return false;
 	}
-
 	@ConfigItem(
 		keyName = "showLootbeamForHighlighted",
 		name = "Highlighted item lootbeams",
 		description = "Configures lootbeams to show for all highlighted items.",
-		position = 30
+		position = 32
 	)
 	default boolean showLootbeamForHighlighted()
 	{
 		return false;
 	}
-
 	@ConfigItem(
 		keyName = "showLootbeamTier",
 		name = "Lootbeam tier",
 		description = "Configures which price tiers will trigger a lootbeam.",
-		position = 31
+		position = 33
 	)
 	default HighlightTier showLootbeamTier()
 	{
 		return HighlightTier.HIGH;
 	}
-
 	@ConfigItem(
 		keyName = "lootbeamStyle",
 		name = "Lootbeam style",
 		description = "Style of lootbeam to use.",
-		position = 32
+		position = 34
 	)
 	default Lootbeam.Style lootbeamStyle()
 	{
 		return Lootbeam.Style.MODERN;
 	}
-
 	@ConfigItem(
 		keyName = "hotkey",
 		name = "Hotkey",
 		description = "Configures the hotkey used by the Ground Items plugin.",
-		position = 33
+		position = 35
 	)
 	default Keybind hotkey()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -31,6 +31,7 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
 import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -47,6 +48,7 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarbitID;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.grounditems.config.DespawnTimerMode;
 import static net.runelite.client.plugins.grounditems.config.ItemHighlightMode.MENU;
 import static net.runelite.client.plugins.grounditems.config.ItemHighlightMode.NONE;
@@ -60,7 +62,6 @@ import net.runelite.client.ui.overlay.components.BackgroundComponent;
 import net.runelite.client.ui.overlay.components.ProgressPieComponent;
 import net.runelite.client.ui.overlay.components.TextComponent;
 import net.runelite.client.util.QuantityFormatter;
-
 public class GroundItemsOverlay extends Overlay
 {
 	private static final int MAX_DISTANCE = 2500;
@@ -74,8 +75,10 @@ public class GroundItemsOverlay extends Overlay
 	private static final Color PUBLIC_TIMER_COLOR = Color.YELLOW;
 	private static final Color PRIVATE_TIMER_COLOR = Color.GREEN;
 	private static final int TIMER_OVERLAY_DIAMETER = 10;
+	private static final int ICON_GAP = 2;
 
 	private final Client client;
+	private final ItemManager itemManager;
 	private final GroundItemsPlugin plugin;
 	private final GroundItemsConfig config;
 	private final StringBuilder itemStringBuilder = new StringBuilder();
@@ -85,11 +88,12 @@ public class GroundItemsOverlay extends Overlay
 	private final Map<WorldPoint, Integer> offsetMap = new HashMap<>();
 
 	@Inject
-	private GroundItemsOverlay(Client client, GroundItemsPlugin plugin, GroundItemsConfig config)
+	private GroundItemsOverlay(Client client, ItemManager itemManager, GroundItemsPlugin plugin, GroundItemsConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.client = client;
+		this.itemManager = itemManager;
 		this.plugin = plugin;
 		this.config = config;
 	}
@@ -128,7 +132,8 @@ public class GroundItemsOverlay extends Overlay
 
 			for (GroundItem item : groundItemList)
 			{
-				item.setOffset(offsetMap.compute(item.getItemLayer().getWorldLocation(), (k, v) -> v != null ? v + 1 : 0));
+				item.setOffset(offsetMap.compute(item.getItemLayer().getWorldLocation(),
+						(k, v) -> v != null ? v + 1 : 0));
 
 				if (groundItem != null)
 				{
@@ -136,24 +141,24 @@ public class GroundItemsOverlay extends Overlay
 				}
 
 				if (plugin.getTextBoxBounds() != null
-					&& item.equals(plugin.getTextBoxBounds().getValue())
-					&& plugin.getTextBoxBounds().getKey().contains(awtMousePos))
+						&& item.equals(plugin.getTextBoxBounds().getValue())
+						&& plugin.getTextBoxBounds().getKey().contains(awtMousePos))
 				{
 					groundItem = item;
 					continue;
 				}
 
 				if (plugin.getHiddenBoxBounds() != null
-					&& item.equals(plugin.getHiddenBoxBounds().getValue())
-					&& plugin.getHiddenBoxBounds().getKey().contains(awtMousePos))
+						&& item.equals(plugin.getHiddenBoxBounds().getValue())
+						&& plugin.getHiddenBoxBounds().getKey().contains(awtMousePos))
 				{
 					groundItem = item;
 					continue;
 				}
 
 				if (plugin.getHighlightBoxBounds() != null
-					&& item.equals(plugin.getHighlightBoxBounds().getValue())
-					&& plugin.getHighlightBoxBounds().getKey().contains(awtMousePos))
+						&& item.equals(plugin.getHighlightBoxBounds().getValue())
+						&& plugin.getHighlightBoxBounds().getKey().contains(awtMousePos))
 				{
 					groundItem = item;
 				}
@@ -183,8 +188,8 @@ public class GroundItemsOverlay extends Overlay
 			final LocalPoint groundPoint = LocalPoint.fromWorld(wv, item.getItemLayer().getWorldLocation());
 
 			if (groundPoint == null
-				|| (groundPoint.getWorldView() == WorldView.TOPLEVEL && localLocation.distanceTo(groundPoint) > MAX_DISTANCE)
-				|| !plugin.shouldDisplayItem(ownershipFilterMode, item.getOwnership(), accountType))
+					|| (groundPoint.getWorldView() == WorldView.TOPLEVEL && localLocation.distanceTo(groundPoint) > MAX_DISTANCE)
+					|| !plugin.shouldDisplayItem(ownershipFilterMode, item.getOwnership(), accountType))
 			{
 				continue;
 			}
@@ -235,34 +240,35 @@ public class GroundItemsOverlay extends Overlay
 			if (item.getId() != ItemID.COINS)
 			{
 				PriceDisplayMode displayMode = config.priceDisplayMode();
+
 				if (displayMode == PriceDisplayMode.BOTH)
 				{
 					if (item.getGePrice() > 0)
 					{
 						itemStringBuilder.append(" (GE: ")
-							.append(QuantityFormatter.quantityToStackSize(item.getGePrice()))
-							.append(" gp)");
+								.append(QuantityFormatter.quantityToStackSize(item.getGePrice()))
+								.append(" gp)");
 					}
 
 					if (item.getHaPrice() > 0)
 					{
 						itemStringBuilder.append(" (HA: ")
-							.append(QuantityFormatter.quantityToStackSize(item.getHaPrice()))
-							.append(" gp)");
+								.append(QuantityFormatter.quantityToStackSize(item.getHaPrice()))
+								.append(" gp)");
 					}
 				}
 				else if (displayMode != PriceDisplayMode.OFF)
 				{
 					final int price = displayMode == PriceDisplayMode.GE
-						? item.getGePrice()
-						: item.getHaPrice();
+							? item.getGePrice()
+							: item.getHaPrice();
 
 					if (price > 0)
 					{
 						itemStringBuilder
-							.append(" (")
-							.append(QuantityFormatter.quantityToStackSize(price))
-							.append(" gp)");
+								.append(" (")
+								.append(QuantityFormatter.quantityToStackSize(price))
+								.append(" gp)");
 					}
 				}
 			}
@@ -270,7 +276,8 @@ public class GroundItemsOverlay extends Overlay
 			final String itemString = itemStringBuilder.toString();
 			itemStringBuilder.setLength(0);
 
-			final Point textPoint = Perspective.getCanvasTextLocation(client,
+			final Point textPoint = Perspective.getCanvasTextLocation(
+				client,
 				graphics,
 				groundPoint,
 				itemString,
@@ -282,11 +289,21 @@ public class GroundItemsOverlay extends Overlay
 			}
 
 			final int offset = plugin.isHotKeyPressed()
-				? item.getOffset()
-				: offsetMap.compute(item.getItemLayer().getWorldLocation(), (k, v) -> v != null ? v + 1 : 0);
+			? item.getOffset()
+			: offsetMap.compute(
+				item.getItemLayer().getWorldLocation(),
+				(k, v) -> v != null ? v + 1 : 0);
 
 			final int textX = textPoint.getX();
 			final int textY = textPoint.getY() - (STRING_GAP * offset);
+
+			final BufferedImage itemImage = config.showItemIcons()
+					? itemManager.getImage(item.getId())
+					: null;
+
+			final int iconSize = config.iconSize();
+			final int iconWidth = itemImage != null ? iconSize + ICON_GAP : 0;
+			final int itemTextX = textX + iconWidth;
 
 			if (plugin.isHotKeyPressed())
 			{
@@ -321,7 +338,6 @@ public class GroundItemsOverlay extends Overlay
 				else if (mouseInHiddenBox)
 				{
 					plugin.setHiddenBoxBounds(new SimpleEntry<>(itemHiddenBox, item));
-
 				}
 				else if (mouseInHighlightBox)
 				{
@@ -329,7 +345,6 @@ public class GroundItemsOverlay extends Overlay
 				}
 
 				boolean topItem = topGroundItem == item;
-
 				// Draw background if hovering
 				if (topItem && (mouseInBox || mouseInHiddenBox || mouseInHighlightBox))
 				{
@@ -338,12 +353,21 @@ public class GroundItemsOverlay extends Overlay
 				}
 
 				// Draw hidden box
-				drawRectangle(graphics, itemHiddenBox, topItem && mouseInHiddenBox ? Color.RED : color, item.hidden, true);
+				drawRectangle(
+						graphics,
+						itemHiddenBox,
+						topItem && mouseInHiddenBox ? Color.RED : color,
+						item.hidden,
+						true);
 
 				// Draw highlight box
-				drawRectangle(graphics, itemHighlightBox, topItem && mouseInHighlightBox ? Color.GREEN : color, item.highlighted, false);
+				drawRectangle(
+						graphics,
+						itemHighlightBox,
+						topItem && mouseInHighlightBox ? Color.GREEN : color,
+						item.highlighted,
+						false);
 			}
-
 			// When the hotkey is pressed the hidden/highlight boxes are drawn to the right of the text,
 			// so always draw the pie since it is on the left hand side.
 			if (groundItemTimers == DespawnTimerMode.PIE || plugin.isHotKeyPressed())
@@ -354,10 +378,12 @@ public class GroundItemsOverlay extends Overlay
 			{
 				Instant despawnTime = calculateDespawnTime(item);
 				Color timerColor = getItemTimerColor(item);
+
 				if (despawnTime != null && timerColor != null)
 				{
 					long despawnTimeMillis = despawnTime.toEpochMilli() - Instant.now().toEpochMilli();
 					final String timerText;
+
 					if (groundItemTimers == DespawnTimerMode.SECONDS)
 					{
 						timerText = String.format(" - %.1f", despawnTimeMillis / 1000f);
@@ -370,18 +396,46 @@ public class GroundItemsOverlay extends Overlay
 					// The timer text is drawn separately to have its own color, and is intentionally not included
 					// in the getCanvasTextLocation() call because the timer text can change per frame and we do not
 					// use a monospaced font, which causes the text location on screen to jump around slightly each frame.
-					textComponent.setText(timerText);
-					textComponent.setColor(timerColor);
+					textComponent.setText(itemString + timerText);
+					textComponent.setColor(color);
 					textComponent.setOutline(outline);
-					textComponent.setPosition(new java.awt.Point(textX + fm.stringWidth(itemString), textY));
+					textComponent.setPosition(new java.awt.Point(itemTextX, textY));
 					textComponent.render(graphics);
+
+					if (itemImage != null)
+					{
+						final int iconY = textY - iconSize + 2;
+
+						graphics.drawImage(
+								itemImage,
+								textX,
+								iconY,
+								iconSize,
+								iconSize,
+								null);
+					}
+
+					continue;
 				}
+			}
+
+			if (itemImage != null)
+			{
+				final int iconY = textY - iconSize + 2;
+
+				graphics.drawImage(
+						itemImage,
+						textX,
+						iconY,
+						iconSize,
+						iconSize,
+						null);
 			}
 
 			textComponent.setText(itemString);
 			textComponent.setColor(color);
 			textComponent.setOutline(outline);
-			textComponent.setPosition(new java.awt.Point(textX, textY));
+			textComponent.setPosition(new java.awt.Point(itemTextX, textY));
 			textComponent.render(graphics);
 		}
 
@@ -391,12 +445,14 @@ public class GroundItemsOverlay extends Overlay
 	private Instant calculateDespawnTime(GroundItem groundItem)
 	{
 		Instant spawnTime = groundItem.getSpawnTime();
+
 		if (spawnTime == null)
 		{
 			return null;
 		}
 
 		Instant despawnTime = spawnTime.plus(groundItem.getDespawnTime());
+
 		if (Instant.now().isAfter(despawnTime))
 		{
 			// that's weird
@@ -409,6 +465,7 @@ public class GroundItemsOverlay extends Overlay
 	private Color getItemTimerColor(GroundItem groundItem)
 	{
 		final Instant spawnTime = groundItem.getSpawnTime();
+
 		if (spawnTime == null)
 		{
 			return null;
@@ -429,10 +486,12 @@ public class GroundItemsOverlay extends Overlay
 
 		// otherwise it is private until visibleTime, then it is public
 		final Instant visibleTime = spawnTime.plus(groundItem.getVisibleTime());
+
 		if (visibleTime.isAfter(now))
 		{
 			return PRIVATE_TIMER_COLOR;
 		}
+
 		if (despawnTime.isAfter(now))
 		{
 			return PUBLIC_TIMER_COLOR;
@@ -453,16 +512,18 @@ public class GroundItemsOverlay extends Overlay
 			return;
 		}
 
-		float percent = (float) (now.toEpochMilli() - spawnTime.toEpochMilli()) / (despawnTime.toEpochMilli() - spawnTime.toEpochMilli());
+		float percent = (float) (now.toEpochMilli() - spawnTime.toEpochMilli())
+				/ (despawnTime.toEpochMilli() - spawnTime.toEpochMilli());
 
 		progressPieComponent.setDiameter(TIMER_OVERLAY_DIAMETER);
 		// Shift over to not be on top of the text
 		int x = textX - TIMER_OVERLAY_DIAMETER;
 		int y = textY - TIMER_OVERLAY_DIAMETER / 2;
+
 		progressPieComponent.setPosition(new Point(x, y));
 		progressPieComponent.setFill(fillColor);
 		progressPieComponent.setBorderColor(fillColor);
-		progressPieComponent.setProgress(1 - percent); // inverse so pie drains over time
+		progressPieComponent.setProgress(1 - percent);
 		progressPieComponent.render(graphics);
 	}
 
@@ -481,25 +542,20 @@ public class GroundItemsOverlay extends Overlay
 
 		graphics.setColor(Color.WHITE);
 		// Minus symbol
-		graphics.drawLine
-			(
+		graphics.drawLine(
 				rect.x + 2,
 				rect.y + (rect.height / 2),
 				rect.x + rect.width - 2,
-				rect.y + (rect.height / 2)
-			);
+				rect.y + (rect.height / 2));
 
 		if (!hiddenBox)
 		{
 			// Plus symbol
-			graphics.drawLine
-				(
+			graphics.drawLine(
 					rect.x + (rect.width / 2),
 					rect.y + 2,
 					rect.x + (rect.width / 2),
-					rect.y + rect.height - 2
-				);
+					rect.y + rect.height - 2);
 		}
-
 	}
 }


### PR DESCRIPTION
<img width="567" height="435" alt="Untitled" src="https://github.com/user-attachments/assets/340e0fe4-3f40-49f4-bf8c-f0ebd403d343" />

Adds optional **item icons** to the Ground Items overlay.

Changes:
- Displays the item icon alongside the ground item name.
- Adds a toggle to enable or disable ground item icons. (Default: off)
- Adds a configurable icon size.
