### PR TITLE
menuentryswapper: reset custom item/npc/object swaps on Reset

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -231,6 +231,35 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swaps.clear();
 	}
 
+	@Override
+	public void resetConfiguration()
+	{
+		// Item swaps live in two different config groups depending on left-click vs shift-click
+		removeKeysWithPrefix(MenuEntrySwapperConfig.GROUP, ITEM_KEY_PREFIX);
+		removeKeysWithPrefix(SHIFTCLICK_CONFIG_GROUP, ITEM_KEY_PREFIX);
+
+		// Everything else lives in the same group, split by prefix instead.
+		// Note: "npc_shift_123" also starts with "npc_", so the base prefix
+		// already covers the shift-click variant too - no need to query it separately.
+		removeKeysWithPrefix(MenuEntrySwapperConfig.GROUP, OBJECT_KEY_PREFIX);
+		removeKeysWithPrefix(MenuEntrySwapperConfig.GROUP, NPC_KEY_PREFIX);
+		removeKeysWithPrefix(MenuEntrySwapperConfig.GROUP, WORN_ITEM_KEY_PREFIX);
+		removeKeysWithPrefix(MenuEntrySwapperConfig.GROUP, UI_KEY_PREFIX);
+	}
+
+	private void removeKeysWithPrefix(String group, String keyPrefix)
+	{
+		for (String key : configManager.getConfigurationKeys(group + "." + keyPrefix))
+		{
+			// getConfigurationKeys returns "group.key" - split off the group part
+			String[] split = key.split("\\.", 2);
+			if (split.length == 2)
+			{
+				configManager.unsetConfiguration(split[0], split[1]);
+			}
+		}
+	}
+
 	@VisibleForTesting
 	void setupSwaps()
 	{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPluginTest.java
@@ -29,6 +29,8 @@ import com.google.inject.Inject;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import net.runelite.api.Client;
 import net.runelite.api.KeyCode;
 import net.runelite.api.Menu;
@@ -384,5 +386,32 @@ public class MenuEntrySwapperPluginTest
 			menu("Configure", "Fairy ring", MenuAction.GAME_OBJECT_FIRST_OPTION),
 			menu("Last-destination (AIQ)", "Fairy ring", MenuAction.GAME_OBJECT_SECOND_OPTION),
 		}, argumentCaptor.getValue());
+	}
+
+
+	@Test
+	public void testResetConfigurationClearsCustomSwaps()
+	{
+		// Simulate the user having previously set one custom swap of each kind
+		when(configManager.getConfigurationKeys("menuentryswapper.item_"))
+				.thenReturn(List.of("menuentryswapper.item_995"));
+		when(configManager.getConfigurationKeys("shiftclick.item_"))
+				.thenReturn(List.of("shiftclick.item_995"));
+		when(configManager.getConfigurationKeys("menuentryswapper.object_"))
+				.thenReturn(List.of("menuentryswapper.object_100"));
+		when(configManager.getConfigurationKeys("menuentryswapper.npc_"))
+				.thenReturn(List.of("menuentryswapper.npc_43", "menuentryswapper.npc_shift_43"));
+		when(configManager.getConfigurationKeys("menuentryswapper.wornitem_"))
+				.thenReturn(Collections.emptyList());
+		when(configManager.getConfigurationKeys("menuentryswapper.ui_"))
+				.thenReturn(Collections.emptyList());
+
+		menuEntrySwapperPlugin.resetConfiguration();
+
+		verify(configManager).unsetConfiguration("menuentryswapper", "item_995");
+		verify(configManager).unsetConfiguration("shiftclick", "item_995");
+		verify(configManager).unsetConfiguration("menuentryswapper", "object_100");
+		verify(configManager).unsetConfiguration("menuentryswapper", "npc_43");
+		verify(configManager).unsetConfiguration("menuentryswapper", "npc_shift_43");
 	}
 }


### PR DESCRIPTION
Implements resetConfiguration() for MenuEntrySwapperPlugin.

Previously, clicking the plugin's Reset button only reset declared config items via setDefaultConfiguration(). Custom swaps created through shift-right-click are stored under dynamically generated keys (e.g. item_995) rather than declared @ConfigItems, so they were not cleared.

This adds resetConfiguration() to remove these dynamically generated keys from both config groups involved. Item shift-click swaps are stored separately in the shiftclick group.

Close #20328