### PR TITLE
gpu: regions: add toa lobby

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
@@ -460,3 +460,7 @@ r 42 158
 // keldagrim tunnel
 n
 r 43 158
+
+// toa lobby
+n
+r 52 142


### PR DESCRIPTION
prevents seeing the dungeon from icthlarin's little helper while in the lobby

<img width="1530" height="919" alt="image" src="https://github.com/user-attachments/assets/15ef1975-2fc1-4787-8001-080943e00d3a" />
