### PR TITLE
Added the option to adjust the rendering scale of the 3D scene (see discussion #19704)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -838,8 +838,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 	@Override
 	public void preSceneDraw(Scene scene, Projection entityProjection,
-	                         float cameraX, float cameraY, float cameraZ, float cameraPitch, float cameraYaw,
-	                         int minLevel, int level, int maxLevel, Set<Integer> hideRoofIds)
+		float cameraX, float cameraY, float cameraZ, float cameraPitch, float cameraYaw,
+		int minLevel, int level, int maxLevel, Set<Integer> hideRoofIds)
 	{
 		SceneContext ctx = context(scene);
 		if (ctx == null)
@@ -876,7 +876,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	}
 
 	private void preSceneDrawToplevel(Scene scene,
-	                                  float cameraX, float cameraY, float cameraZ, float cameraPitch, float cameraYaw)
+		float cameraX, float cameraY, float cameraZ, float cameraPitch, float cameraYaw)
 	{
 		scene.setDrawDistance(getDrawDistance());
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -72,7 +72,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginInstantiationException;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.plugins.gpu.config.AntiAliasingMode;
-import net.runelite.client.plugins.gpu.config.GameScalingMode;
 import net.runelite.client.plugins.gpu.config.UIScalingMode;
 import net.runelite.client.plugins.gpu.template.Template;
 import net.runelite.client.ui.ClientUI;
@@ -1150,7 +1149,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 		int defaultFbo = awtContext.getFramebuffer(false);
 
-		if (sceneFooResolveRequired) {
+		if (sceneFooResolveRequired)
+		{
 			glBindFramebuffer(GL_READ_FRAMEBUFFER, fboScene);
 			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fboSceneResolve);
 			glBlitFramebuffer(0, 0, srcWidth, srcHeight, 0, 0, srcWidth, srcHeight,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -72,6 +72,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginInstantiationException;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.plugins.gpu.config.AntiAliasingMode;
+import net.runelite.client.plugins.gpu.config.GameScalingMode;
 import net.runelite.client.plugins.gpu.config.UIScalingMode;
 import net.runelite.client.plugins.gpu.template.Template;
 import net.runelite.client.ui.ClientUI;
@@ -171,6 +172,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	private int lastStretchedCanvasWidth;
 	private int lastStretchedCanvasHeight;
 	private AntiAliasingMode lastAntiAliasingMode;
+	private double lastGameResolutionScale;
+	private GameScalingMode lastGameScalingMode;
 	private int lastAnisotropicFilteringLevel = -1;
 
 	private GpuFloatBuffer uniformBuffer;
@@ -905,10 +908,13 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		final int viewportHeight = client.getViewportHeight();
 		final int viewportWidth = client.getViewportWidth();
 
+		final double gameResolutionScale = config.gameResolutionScale() * 0.01;
+
 		// Setup FBO and anti-aliasing
-		final AntiAliasingMode antiAliasingMode = config.antiAliasingMode();
 		{
+			final AntiAliasingMode antiAliasingMode = config.antiAliasingMode();
 			final Dimension stretchedDimensions = client.getStretchedDimensions();
+			final GameScalingMode gameScalingMode = config.gameScalingMode();
 
 			final int stretchedCanvasWidth = client.isStretchedEnabled() ? stretchedDimensions.width : canvasWidth;
 			final int stretchedCanvasHeight = client.isStretchedEnabled() ? stretchedDimensions.height : canvasHeight;
@@ -916,7 +922,9 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			// Re-create fbo
 			if (lastStretchedCanvasWidth != stretchedCanvasWidth
 				|| lastStretchedCanvasHeight != stretchedCanvasHeight
-				|| lastAntiAliasingMode != antiAliasingMode)
+				|| lastAntiAliasingMode != antiAliasingMode
+				|| lastGameResolutionScale != gameResolutionScale
+				|| lastGameScalingMode != gameScalingMode)
 			{
 				shutdownFbo();
 
@@ -926,15 +934,16 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 				final int maxSamples = glGetInteger(GL_MAX_SAMPLES);
 				final int samples = forcedAASamples != 0 ? forcedAASamples :
 					Math.min(antiAliasingMode.getSamples(), maxSamples);
-				final double renderScale = antiAliasingMode.getRenderScale();
 
-				log.debug("AA samples: {}, max samples: {}, forced samples: {}, render scale: {}", samples, maxSamples, forcedAASamples, renderScale);
+				log.debug("AA samples: {}, max samples: {}, forced samples: {}, render scale: {}", samples, maxSamples, forcedAASamples, gameResolutionScale);
 
-				initFbo(stretchedCanvasWidth, stretchedCanvasHeight, samples, renderScale);
+				initFbo(stretchedCanvasWidth, stretchedCanvasHeight, samples, gameResolutionScale);
 
 				lastStretchedCanvasWidth = stretchedCanvasWidth;
 				lastStretchedCanvasHeight = stretchedCanvasHeight;
 				lastAntiAliasingMode = antiAliasingMode;
+				lastGameResolutionScale = gameResolutionScale;
+				lastGameScalingMode = gameScalingMode;
 			}
 
 			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fboScene);
@@ -975,7 +984,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			renderWidthOff = (int) Math.floor(scaleFactorX * (renderWidthOff)) - padding;
 		}
 
-		glDpiAwareViewport(renderWidthOff, renderCanvasHeight - renderViewportHeight - renderHeightOff, renderViewportWidth, renderViewportHeight, antiAliasingMode.getRenderScale());
+		glDpiAwareViewport(renderWidthOff, renderCanvasHeight - renderViewportHeight - renderHeightOff, renderViewportWidth, renderViewportHeight, gameResolutionScale);
 
 		glUseProgram(glProgram);
 
@@ -1092,10 +1101,10 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 		final GraphicsConfiguration graphicsConfiguration = clientUI.getGraphicsConfiguration();
 		final AffineTransform transform = graphicsConfiguration.getDefaultTransform();
-		final double renderScale = config.antiAliasingMode().getRenderScale();
+		final double gameResolutionScale = config.gameResolutionScale() * 0.01;
 
-		int srcWidth = getScaledValue(transform.getScaleX() * renderScale, width);
-		int srcHeight = getScaledValue(transform.getScaleY() * renderScale, height);
+		int srcWidth = getScaledValue(transform.getScaleX() * gameResolutionScale, width);
+		int srcHeight = getScaledValue(transform.getScaleY() * gameResolutionScale, height);
 
 		width = getScaledValue(transform.getScaleX(), width);
 		height = getScaledValue(transform.getScaleY(), height);
@@ -1104,7 +1113,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, fboScene);
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, defaultFbo);
 		glBlitFramebuffer(0, 0, srcWidth, srcHeight, 0, 0, width, height,
-			GL_COLOR_BUFFER_BIT, GL_NEAREST);
+			GL_COLOR_BUFFER_BIT, config.gameScalingMode().getScalingMode());
 
 		// Reset
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, defaultFbo);
@@ -2150,15 +2159,15 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		glDpiAwareViewport(x, y, width, height, 1.0);
 	}
 
-	private void glDpiAwareViewport(final int x, final int y, final int width, final int height, final double renderScale)
+	private void glDpiAwareViewport(final int x, final int y, final int width, final int height, final double gameResolutionScale)
 	{
 		final GraphicsConfiguration graphicsConfiguration = clientUI.getGraphicsConfiguration();
 		final AffineTransform t = graphicsConfiguration.getDefaultTransform();
 		glViewport(
-			getScaledValue(t.getScaleX() * renderScale, x),
-			getScaledValue(t.getScaleY() * renderScale, y),
-			getScaledValue(t.getScaleX() * renderScale, width),
-			getScaledValue(t.getScaleY() * renderScale, height));
+			getScaledValue(t.getScaleX() * gameResolutionScale, x),
+			getScaledValue(t.getScaleY() * gameResolutionScale, y),
+			getScaledValue(t.getScaleX() * gameResolutionScale, width),
+			getScaledValue(t.getScaleY() * gameResolutionScale, height));
 	}
 
 	private int getDrawDistance()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -771,13 +771,13 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		interfaceTexture = -1;
 	}
 
-	private void initFbo(int width, int height, int aaSamples)
+	private void initFbo(int width, int height, int aaSamples, double renderScale)
 	{
 		final GraphicsConfiguration graphicsConfiguration = clientUI.getGraphicsConfiguration();
 		final AffineTransform transform = graphicsConfiguration.getDefaultTransform();
 
-		width = getScaledValue(transform.getScaleX(), width);
-		height = getScaledValue(transform.getScaleY(), height);
+		width = getScaledValue(transform.getScaleX() * renderScale, width);
+		height = getScaledValue(transform.getScaleY() * renderScale, height);
 
 		if (aaSamples > 0)
 		{
@@ -838,8 +838,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 	@Override
 	public void preSceneDraw(Scene scene, Projection entityProjection,
-		float cameraX, float cameraY, float cameraZ, float cameraPitch, float cameraYaw,
-		int minLevel, int level, int maxLevel, Set<Integer> hideRoofIds)
+	                         float cameraX, float cameraY, float cameraZ, float cameraPitch, float cameraYaw,
+	                         int minLevel, int level, int maxLevel, Set<Integer> hideRoofIds)
 	{
 		SceneContext ctx = context(scene);
 		if (ctx == null)
@@ -876,7 +876,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	}
 
 	private void preSceneDrawToplevel(Scene scene,
-		float cameraX, float cameraY, float cameraZ, float cameraPitch, float cameraYaw)
+	                                  float cameraX, float cameraY, float cameraZ, float cameraPitch, float cameraYaw)
 	{
 		scene.setDrawDistance(getDrawDistance());
 
@@ -906,8 +906,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		final int viewportWidth = client.getViewportWidth();
 
 		// Setup FBO and anti-aliasing
+		final AntiAliasingMode antiAliasingMode = config.antiAliasingMode();
 		{
-			final AntiAliasingMode antiAliasingMode = config.antiAliasingMode();
 			final Dimension stretchedDimensions = client.getStretchedDimensions();
 
 			final int stretchedCanvasWidth = client.isStretchedEnabled() ? stretchedDimensions.width : canvasWidth;
@@ -926,10 +926,11 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 				final int maxSamples = glGetInteger(GL_MAX_SAMPLES);
 				final int samples = forcedAASamples != 0 ? forcedAASamples :
 					Math.min(antiAliasingMode.getSamples(), maxSamples);
+				final double renderScale = antiAliasingMode.getRenderScale();
 
-				log.debug("AA samples: {}, max samples: {}, forced samples: {}", samples, maxSamples, forcedAASamples);
+				log.debug("AA samples: {}, max samples: {}, forced samples: {}, render scale: {}", samples, maxSamples, forcedAASamples, renderScale);
 
-				initFbo(stretchedCanvasWidth, stretchedCanvasHeight, samples);
+				initFbo(stretchedCanvasWidth, stretchedCanvasHeight, samples, renderScale);
 
 				lastStretchedCanvasWidth = stretchedCanvasWidth;
 				lastStretchedCanvasHeight = stretchedCanvasHeight;
@@ -974,7 +975,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			renderWidthOff = (int) Math.floor(scaleFactorX * (renderWidthOff)) - padding;
 		}
 
-		glDpiAwareViewport(renderWidthOff, renderCanvasHeight - renderViewportHeight - renderHeightOff, renderViewportWidth, renderViewportHeight);
+		glDpiAwareViewport(renderWidthOff, renderCanvasHeight - renderViewportHeight - renderHeightOff, renderViewportWidth, renderViewportHeight, antiAliasingMode.getRenderScale());
 
 		glUseProgram(glProgram);
 
@@ -1091,6 +1092,10 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 		final GraphicsConfiguration graphicsConfiguration = clientUI.getGraphicsConfiguration();
 		final AffineTransform transform = graphicsConfiguration.getDefaultTransform();
+		final double renderScale = config.antiAliasingMode().getRenderScale();
+
+		int srcWidth = getScaledValue(transform.getScaleX() * renderScale, width);
+		int srcHeight = getScaledValue(transform.getScaleY() * renderScale, height);
 
 		width = getScaledValue(transform.getScaleX(), width);
 		height = getScaledValue(transform.getScaleY(), height);
@@ -1098,7 +1103,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		int defaultFbo = awtContext.getFramebuffer(false);
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, fboScene);
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, defaultFbo);
-		glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
+		glBlitFramebuffer(0, 0, srcWidth, srcHeight, 0, 0, width, height,
 			GL_COLOR_BUFFER_BIT, GL_NEAREST);
 
 		// Reset
@@ -2142,13 +2147,18 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 	private void glDpiAwareViewport(final int x, final int y, final int width, final int height)
 	{
+		glDpiAwareViewport(x, y, width, height, 1.0);
+	}
+
+	private void glDpiAwareViewport(final int x, final int y, final int width, final int height, final double renderScale)
+	{
 		final GraphicsConfiguration graphicsConfiguration = clientUI.getGraphicsConfiguration();
 		final AffineTransform t = graphicsConfiguration.getDefaultTransform();
 		glViewport(
-			getScaledValue(t.getScaleX(), x),
-			getScaledValue(t.getScaleY(), y),
-			getScaledValue(t.getScaleX(), width),
-			getScaledValue(t.getScaleY(), height));
+			getScaledValue(t.getScaleX() * renderScale, x),
+			getScaledValue(t.getScaleY() * renderScale, y),
+			getScaledValue(t.getScaleX() * renderScale, width),
+			getScaledValue(t.getScaleY() * renderScale, height));
 	}
 
 	private int getDrawDistance()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -159,6 +159,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	private int vboUiHandle;
 
 	private int fboScene;
+	private int fboSceneResolve;
+	private int fboSceneResolveColor;
 	private boolean sceneFboValid;
 	private int rboColorBuffer;
 	private int rboDepthBuffer;
@@ -173,8 +175,10 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	private int lastStretchedCanvasHeight;
 	private AntiAliasingMode lastAntiAliasingMode;
 	private double lastGameResolutionScale;
-	private GameScalingMode lastGameScalingMode;
+	private int lastGameScalingMode;
 	private int lastAnisotropicFilteringLevel = -1;
+
+	private boolean sceneFooResolveRequired;
 
 	private GpuFloatBuffer uniformBuffer;
 
@@ -298,6 +302,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			try
 			{
 				fboScene = -1;
+				fboSceneResolve = -1;
+				fboSceneResolveColor = -1;
 				lastAnisotropicFilteringLevel = -1;
 
 				AWTContext.loadNatives();
@@ -813,6 +819,25 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			throw new RuntimeException("FBO is incomplete. status: " + status);
 		}
 
+		//  Resolve render buffer
+		if (aaSamples > 0 && renderScale != 1.0)
+		{
+			fboSceneResolve = glGenFramebuffers();
+			glBindFramebuffer(GL_FRAMEBUFFER, fboSceneResolve);
+
+			fboSceneResolveColor = glGenRenderbuffers();
+			glBindRenderbuffer(GL_RENDERBUFFER, fboSceneResolveColor);
+
+			glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, width, height);
+			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, fboSceneResolveColor);
+
+			int statusResolve = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+			if (statusResolve != GL_FRAMEBUFFER_COMPLETE)
+			{
+				throw new RuntimeException("FBO is incomplete. status: " + statusResolve);
+			}
+		}
+
 		// Reset
 		glBindFramebuffer(GL_FRAMEBUFFER, awtContext.getFramebuffer(false));
 		glBindRenderbuffer(GL_RENDERBUFFER, 0);
@@ -824,6 +849,18 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		{
 			glDeleteFramebuffers(fboScene);
 			fboScene = -1;
+		}
+
+		if (fboSceneResolve != -1)
+		{
+			glDeleteFramebuffers(fboSceneResolve);
+			fboSceneResolve = -1;
+		}
+
+		if (fboSceneResolveColor != -1)
+		{
+			glDeleteRenderbuffers(fboSceneResolveColor);
+			fboSceneResolveColor = -1;
 		}
 
 		if (rboColorBuffer != 0)
@@ -914,7 +951,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		{
 			final AntiAliasingMode antiAliasingMode = config.antiAliasingMode();
 			final Dimension stretchedDimensions = client.getStretchedDimensions();
-			final GameScalingMode gameScalingMode = config.gameScalingMode();
+			final int gameScalingMode = config.gameScalingMode().getScalingMode();
 
 			final int stretchedCanvasWidth = client.isStretchedEnabled() ? stretchedDimensions.width : canvasWidth;
 			final int stretchedCanvasHeight = client.isStretchedEnabled() ? stretchedDimensions.height : canvasHeight;
@@ -934,6 +971,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 				final int maxSamples = glGetInteger(GL_MAX_SAMPLES);
 				final int samples = forcedAASamples != 0 ? forcedAASamples :
 					Math.min(antiAliasingMode.getSamples(), maxSamples);
+				sceneFooResolveRequired = samples > 0 && gameResolutionScale != 1.0;
 
 				log.debug("AA samples: {}, max samples: {}, forced samples: {}, render scale: {}", samples, maxSamples, forcedAASamples, gameResolutionScale);
 
@@ -1099,9 +1137,10 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		int width = lastStretchedCanvasWidth;
 		int height = lastStretchedCanvasHeight;
 
+		double gameResolutionScale = lastGameResolutionScale;
+
 		final GraphicsConfiguration graphicsConfiguration = clientUI.getGraphicsConfiguration();
 		final AffineTransform transform = graphicsConfiguration.getDefaultTransform();
-		final double gameResolutionScale = config.gameResolutionScale() * 0.01;
 
 		int srcWidth = getScaledValue(transform.getScaleX() * gameResolutionScale, width);
 		int srcHeight = getScaledValue(transform.getScaleY() * gameResolutionScale, height);
@@ -1110,10 +1149,25 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		height = getScaledValue(transform.getScaleY(), height);
 
 		int defaultFbo = awtContext.getFramebuffer(false);
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, fboScene);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, defaultFbo);
-		glBlitFramebuffer(0, 0, srcWidth, srcHeight, 0, 0, width, height,
-			GL_COLOR_BUFFER_BIT, config.gameScalingMode().getScalingMode());
+
+		if (sceneFooResolveRequired) {
+			glBindFramebuffer(GL_READ_FRAMEBUFFER, fboScene);
+			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fboSceneResolve);
+			glBlitFramebuffer(0, 0, srcWidth, srcHeight, 0, 0, srcWidth, srcHeight,
+				GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+			glBindFramebuffer(GL_READ_FRAMEBUFFER, fboSceneResolve);
+			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, defaultFbo);
+			glBlitFramebuffer(0, 0, srcWidth, srcHeight, 0, 0, width, height,
+				GL_COLOR_BUFFER_BIT, lastGameScalingMode);
+		}
+		else
+		{
+			glBindFramebuffer(GL_READ_FRAMEBUFFER, fboScene);
+			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, defaultFbo);
+			glBlitFramebuffer(0, 0, srcWidth, srcHeight, 0, 0, width, height,
+				GL_COLOR_BUFFER_BIT, lastGameScalingMode);
+		}
 
 		// Reset
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, defaultFbo);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
@@ -28,10 +28,12 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
 import static net.runelite.client.plugins.gpu.GpuPlugin.MAX_DISTANCE;
 import static net.runelite.client.plugins.gpu.GpuPlugin.MAX_FOG_DEPTH;
 import net.runelite.client.plugins.gpu.config.AntiAliasingMode;
 import net.runelite.client.plugins.gpu.config.ColorBlindMode;
+import net.runelite.client.plugins.gpu.config.GameScalingMode;
 import net.runelite.client.plugins.gpu.config.UIScalingMode;
 
 @ConfigGroup(GpuPluginConfig.GROUP)
@@ -101,10 +103,37 @@ public interface GpuPluginConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "gameResolutionScale",
+		name = "Game Resolution",
+		description = "Change the resolution the game is rendered in relative to the actual window resolution.",
+		position = 4
+	)
+	@Units(Units.PERCENT)
+	@Range(
+		min = 1,
+		max = 200
+	)
+	default int gameResolutionScale()
+	{
+		return 100;
+	}
+
+	@ConfigItem(
+		keyName = "gameScalingMode",
+		name = "Game Scaling Mode",
+		description = "Sampling function to use for the game resolution setting.",
+		position = 5
+	)
+	default GameScalingMode gameScalingMode()
+	{
+		return GameScalingMode.NEAREST;
+	}
+
+	@ConfigItem(
 		keyName = "uiScalingMode",
 		name = "UI scaling mode",
 		description = "Sampling function to use for the UI in stretched mode.",
-		position = 4
+		position = 6
 	)
 	default UIScalingMode uiScalingMode()
 	{
@@ -118,7 +147,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "fogDepth",
 		name = "Fog depth",
 		description = "Distance from the scene edge the fog starts.",
-		position = 5
+		position = 7
 	)
 	default int fogDepth()
 	{
@@ -133,7 +162,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "anisotropicFilteringLevel",
 		name = "Anisotropic filtering",
 		description = "Configures the anisotropic filtering level.",
-		position = 7
+		position = 8
 	)
 	default int anisotropicFilteringLevel()
 	{
@@ -144,7 +173,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "colorBlindMode",
 		name = "Colorblindness correction",
 		description = "Adjusts colors to account for colorblindness.",
-		position = 8
+		position = 9
 	)
 	default ColorBlindMode colorBlindMode()
 	{
@@ -159,7 +188,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "colorBlindIntensity",
 		name = "Colorblindness intensity",
 		description = "Strength of the colorblindness correction effect.",
-		position = 9
+		position = 10
 	)
 	default int colorBlindIntensity()
 	{
@@ -170,7 +199,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "brightTextures",
 		name = "Bright textures",
 		description = "Use old texture lighting method which results in brighter game textures.",
-		position = 10
+		position = 11
 	)
 	default boolean brightTextures()
 	{
@@ -181,7 +210,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "unlockFps",
 		name = "Unlock FPS",
 		description = "Removes the 50 FPS cap for camera movement.",
-		position = 11
+		position = 12
 	)
 	default boolean unlockFps()
 	{
@@ -199,7 +228,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "vsyncMode",
 		name = "Vsync mode",
 		description = "Method to synchronize frame rate with refresh rate.",
-		position = 12
+		position = 13
 	)
 	default SyncMode syncMode()
 	{
@@ -210,7 +239,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "fpsTarget",
 		name = "FPS target",
 		description = "Target FPS when 'Unlock FPS' is enabled and 'Vsync mode' is off.",
-		position = 13
+		position = 14
 	)
 	@Range(
 		min = 1,
@@ -225,7 +254,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "removeVertexSnapping",
 		name = "Remove vertex snapping",
 		description = "Removes vertex snapping from most animations.",
-		position = 14
+		position = 15
 	)
 	default boolean removeVertexSnapping()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/config/AntiAliasingMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/config/AntiAliasingMode.java
@@ -31,14 +31,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AntiAliasingMode
 {
-	DISABLED("Disabled", 0),
-	MSAA_2("MSAA x2", 2),
-	MSAA_4("MSAA x4", 4),
-	MSAA_8("MSAA x8", 8),
-	MSAA_16("MSAA x16", 16);
+	SCALE_QUARTER("x0.25", 0, 0.25),
+	SCALE_HALF("x0.5", 0, 0.5),
+	DISABLED("Disabled", 0, 1.0),
+	MSAA_2("MSAA x2", 2, 1.0),
+	MSAA_4("MSAA x4", 4, 1.0),
+	MSAA_8("MSAA x8", 8, 1.0),
+	MSAA_16("MSAA x16", 16, 1.0);
 
 	private final String name;
 	private final int samples;
+	private final double renderScale;
 
 	@Override
 	public String toString()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/config/GameScalingMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/config/GameScalingMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * Copyright (c) 2018, NonaNonia <https://github.com/NonaNonia>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,19 +26,18 @@ package net.runelite.client.plugins.gpu.config;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import static org.lwjgl.opengl.GL11.GL_NEAREST;
+import static org.lwjgl.opengl.GL11.GL_LINEAR;
 
 @Getter
 @RequiredArgsConstructor
-public enum AntiAliasingMode
+public enum GameScalingMode
 {
-	DISABLED("Disabled", 0),
-	MSAA_2("MSAA x2", 2),
-	MSAA_4("MSAA x4", 4),
-	MSAA_8("MSAA x8", 8),
-	MSAA_16("MSAA x16", 16);
+	NEAREST("Nearest", GL_NEAREST),
+	LINEAR("Bilinear", GL_LINEAR);
 
 	private final String name;
-	private final int samples;
+	private final int scalingMode;
 
 	@Override
 	public String toString()
@@ -46,3 +45,8 @@ public enum AntiAliasingMode
 		return name;
 	}
 }
+
+
+
+
+


### PR DESCRIPTION
Added the option to adjust the rendering scale of the 3D scene by applying it to the dimensions of the framebuffer (Fbo) and 3D viewport (not the UI viewport) and the source dimensions during the blitting of the framebuffer. This means the 3D scene gets rendered at a scaled resolution while the output then gets stretched to the correct size.

While this could've been a separate, freely adjustable setting, I decided to add a "x0.5" and "x0.25" option to the AntiAliasingMode dropdown, below the "Disabled" to "MSAA x16" scale of options, as I think that this is the most intuitive place for it.

My motivation came from [this discussion](https://github.com/runelite/runelite/discussions/19704).

I did test it with the Stretched Mode plugin enabled and disabled and I also tested moving it from a retina to a non-retina screen.
It worked as expected. (Even preserving the bug from the release client where moving from a non-retina screen to a retina screen results in 3/4 of the screen being black.)
