### PR TITLE
interact highlight: remove fallback actor highlighting

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/interacthighlight/InteractHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interacthighlight/InteractHighlightOverlay.java
@@ -136,7 +136,7 @@ class InteractHighlightOverlay extends Overlay
 			case EXAMINE_NPC:
 			{
 				NPC npc = entry.getNpc();
-				if (npc != null && config.npcShowHover() && (npc != plugin.getInteractedTarget() || !config.npcShowInteract()))
+				if (npc != null && config.npcShowHover() && (npc != plugin.getInteractedActor() || !config.npcShowInteract()))
 				{
 					Color highlightColor = menuAction == MenuAction.NPC_SECOND_OPTION
 						|| menuAction == MenuAction.WIDGET_TARGET_ON_NPC && WidgetUtil.componentToInterface(client.getSelectedWidget().getId()) == InterfaceID.MAGIC_SPELLBOOK
@@ -156,7 +156,7 @@ class InteractHighlightOverlay extends Overlay
 			case PLAYER_EIGHTH_OPTION:
 			{
 				Player player = entry.getPlayer();
-				if (player != null && config.playerShowHover() && (player != plugin.getInteractedTarget() || !config.npcShowInteract()))
+				if (player != null && config.playerShowHover() && (player != plugin.getInteractedActor() || !config.npcShowInteract()))
 				{
 					modelOutlineRenderer.drawOutline(player, config.borderWidth(), config.playerHoverHighlightColor(), config.outlineFeather());
 				}
@@ -182,7 +182,7 @@ class InteractHighlightOverlay extends Overlay
 			modelOutlineRenderer.drawOutline(interactedObject, config.borderWidth(), clickColor, config.outlineFeather());
 		}
 
-		Actor target = plugin.getInteractedTarget();
+		Actor target = plugin.getInteractedActor();
 		if (target instanceof NPC && config.npcShowInteract())
 		{
 			Color startColor = plugin.isAttacked() ? config.npcAttackHoverHighlightColor() : config.npcHoverHighlightColor();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/interacthighlight/InteractHighlightPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interacthighlight/InteractHighlightPlugin.java
@@ -38,6 +38,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.GroundObject;
 import net.runelite.api.ItemLayer;
 import net.runelite.api.MenuAction;
+import net.runelite.api.NPC;
 import net.runelite.api.Node;
 import net.runelite.api.Player;
 import net.runelite.api.Scene;
@@ -52,7 +53,9 @@ import net.runelite.api.events.InteractingChanged;
 import net.runelite.api.events.ItemDespawned;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.NpcDespawned;
+import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.PlayerDespawned;
+import net.runelite.api.events.PlayerSpawned;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.WidgetUtil;
 import net.runelite.client.config.ConfigManager;
@@ -81,6 +84,8 @@ public class InteractHighlightPlugin extends Plugin
 	private TileObject interactedObject;
 	@Getter(AccessLevel.PACKAGE)
 	private TileItem interactedItem;
+	@Getter(AccessLevel.PACKAGE)
+	@Nullable
 	private Actor interactedActor;
 	@Getter(AccessLevel.PACKAGE)
 	boolean attacked;
@@ -116,11 +121,33 @@ public class InteractHighlightPlugin extends Plugin
 	}
 
 	@Subscribe
+	private void onNpcSpawned(NpcSpawned event)
+	{
+		final Player localPlayer = client.getLocalPlayer();
+		final NPC npc = event.getNpc();
+		if (localPlayer != null && npc == localPlayer.getInteracting())
+		{
+			interactedActor = npc;
+		}
+	}
+
+	@Subscribe
 	public void onNpcDespawned(NpcDespawned npcDespawned)
 	{
 		if (npcDespawned.getNpc() == interactedActor)
 		{
 			interactedActor = null;
+		}
+	}
+
+	@Subscribe
+	private void onPlayerSpawned(PlayerSpawned event)
+	{
+		final Player localPlayer = client.getLocalPlayer();
+		final Player otherPlayer = event.getPlayer();
+		if (localPlayer != null && otherPlayer == localPlayer.getInteracting())
+		{
+			interactedActor = otherPlayer;
 		}
 	}
 
@@ -146,12 +173,11 @@ public class InteractHighlightPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick gameTick)
 	{
-		if (client.getTickCount() > clickTick && client.getLocalDestinationLocation() == null)
+		if (client.getTickCount() > clickTick && client.getLocalDestinationLocation() == null && interactedActor == null)
 		{
 			// when the destination is reached, clear the interacting object
 			interactedObject = null;
 			interactedItem = null;
-			interactedActor = null;
 		}
 	}
 
@@ -159,10 +185,14 @@ public class InteractHighlightPlugin extends Plugin
 	public void onInteractingChanged(InteractingChanged interactingChanged)
 	{
 		if (interactingChanged.getSource() == client.getLocalPlayer()
-				&& client.getTickCount() > clickTick && interactingChanged.getTarget() != interactedActor)
+			&& client.getTickCount() > clickTick)
 		{
-			interactedActor = null;
-			attacked = interactingChanged.getTarget() != null && interactingChanged.getTarget().getCombatLevel() > 0;
+			final Actor target = interactingChanged.getTarget();
+
+			interactedObject = null;
+			interactedItem = null;
+			interactedActor = target;
+			attacked = target != null && target.getCombatLevel() > 0;
 		}
 	}
 
@@ -344,23 +374,6 @@ public class InteractHighlightPlugin extends Plugin
 				return item;
 			}
 		}
-		return null;
-	}
-
-	@Nullable
-	Actor getInteractedTarget()
-	{
-		if (interactedActor != null)
-		{
-			return interactedActor;
-		}
-
-		Player local = client.getLocalPlayer();
-		if (local != null)
-		{
-			return local.getInteracting();
-		}
-
 		return null;
 	}
 }


### PR DESCRIPTION
Previously, when the player had not clicked on an actor (or had clicked
away from an actor) the plugin would fall back on checking the player's
current interaction target. This was presumably done so that NPCs
despawning then respawning could continue to be highlighted, or to let
players know that they are currently in combat with a monster before
their click away takes effect. This has the unfortunate side effect of
producing multiple highlights when clicking away from monsters which is
especially noticeable if auto-retaliate is enabled, or when clicking
items or objects nearby, as the player would see the interact click
color applied to both the currently-interacted actor _and_ whatever they
just clicked on.
    
To rectify this, the plugin checks for interaction on spawned NPCs and
players, and sets the interactedActor when the player's interaction is
changed to a non-null target. (in cases of auto-retaliate, or when
forced into interaction such as during quests)

Fixes #19989