### PR TITLE
item-stats: Show item name in tooltip

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -134,6 +134,13 @@ public interface ItemStatConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showItemName",
+		name = "Show item name",
+		description = "Show item name in tooltip."
+	)
+	default boolean showName()	{ return false;	}
+
+	@ConfigItem(
 		keyName = "colorBetterSomecapped",
 		name = "Better (some capped)",
 		description = "Color to show when some stat changes are capped, but some are not.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -138,7 +138,10 @@ public interface ItemStatConfig extends Config
 		name = "Show item name",
 		description = "Show item name in tooltip."
 	)
-	default boolean showName()	{ return false;	}
+	default boolean showName()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "colorBetterSomecapped",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -125,6 +125,12 @@ public class ItemStatOverlay extends Overlay
 			return null;
 		}
 
+		if (config.showName())
+		{
+			final String name = itemManager.getItemComposition(itemId).getName();
+			tooltipManager.add(new Tooltip(name));
+		}
+
 		if (config.consumableStats())
 		{
 			final Effect change = statChanges.get(itemId);


### PR DESCRIPTION
Tiny QoL option to item stats, to show item name in tooltip