### PR TITLE
Update Item Stats Plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -206,7 +206,10 @@ public interface ItemStatConfig extends Config
 		section = sectionKeybind,
 		position = 0
 	)
-	default boolean requireModifier() { return false; }
+	default boolean requireModifier()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "requireModifierForConsumables",
@@ -215,7 +218,10 @@ public interface ItemStatConfig extends Config
 		section = sectionKeybind,
 		position = 1
 	)
-	default boolean requireModifierForConsumables() { return false; }
+	default boolean requireModifierForConsumables()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "requireModifierForEquipment",
@@ -224,7 +230,10 @@ public interface ItemStatConfig extends Config
 		section = sectionKeybind,
 		position = 2
 	)
-	default boolean requireModifierForEquipment() { return true; }
+	default boolean requireModifierForEquipment()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 		keyName = "modifierKey",
@@ -233,5 +242,8 @@ public interface ItemStatConfig extends Config
 		section = sectionKeybind,
 		position = 3
 	)
-	default Keybind modifierKey() { return Keybind.NOT_SET; }
+	default Keybind modifierKey() 
+	{
+		return Keybind.NOT_SET;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -242,7 +242,7 @@ public interface ItemStatConfig extends Config
 		section = sectionKeybind,
 		position = 3
 	)
-	default Keybind modifierKey() 
+	default Keybind modifierKey()
 	{
 		return Keybind.NOT_SET;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -107,9 +107,9 @@ public interface ItemStatConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showWeight",
-		name = "Show weight",
-		description = "Show weight in tooltip.",
+		keyName = "enableWeight",
+		name = "Enable weight",
+		description = "Enable weight in tooltip.",
 		section = sectionGeneral
 	)
 	default boolean showWeight()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -26,60 +26,69 @@ package net.runelite.client.plugins.itemstats;
 
 import java.awt.Color;
 
-import net.runelite.client.config.*;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Keybind;
 
 @ConfigGroup("itemstat")
 public interface ItemStatConfig extends Config
 {
-	@ConfigSection(name = "General",         description = "General settings",             position = 0)
+	@ConfigSection(
+		name = "General",
+		description = "General settings",
+		position = 0)
 	String sectionGeneral = "general";
 
-	@ConfigSection(name = "Colors",           description = "Color settings",         position = 1)
+	@ConfigSection(
+		name = "Stat Type Display",
+		description = "Stat Type Configuration",
+		position = 1)
+	String sectionStatTypes = "statTypes";
+
+	@ConfigSection(
+		name = "Colors",
+		description = "Color settings",
+		position = 2)
 	String sectionColors = "colors";
 
-	@ConfigSection(name = "Keybind", description = "Keybind settings",       position = 2)
-	String sectionKeybind = "keybind";
+	/*
+	 * GENERAL
+	 */
 
 	@ConfigItem(
-		keyName = "consumableStats",
-		name = "Enable consumable stats",
-		description = "Enables tooltips for consumable items (food, boosts).",
-		section = sectionGeneral
+		keyName = "alwaysShowBaseStats",
+		name = "Always show base stats",
+		description = "Always include the base items stats in the tooltip.",
+		section = sectionGeneral,
+		position = 0
 	)
-	default boolean consumableStats()
+	default boolean alwaysShowBaseStats()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
-		keyName = "equipmentStats",
-		name = "Enable equipment stats",
-		description = "Enables tooltips for equipment items (combat bonuses, weight, prayer bonuses).",
-		section = sectionGeneral
+		keyName = "showStatsInBank",
+		name = "Show stats in bank",
+		description = "Show item stats on bank items tooltip.",
+		section = sectionGeneral,
+		position = 1
 	)
-	default boolean equipmentStats()
+	default boolean showStatsInBank()
 	{
 		return true;
 	}
 
 	@ConfigItem(
 		keyName = "geStats",
-		name = "Enable GE item information",
+		name = "Show GE item information",
 		description = "Shows an item information panel when buying items in the GE.",
-		section = sectionGeneral
+		section = sectionGeneral,
+		position = 2
 	)
 	default boolean geStats()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "relative",
-		name = "Show relative",
-		description = "Show relative stat change in tooltip.",
-		section = sectionGeneral
-	)
-	default boolean relative()
 	{
 		return true;
 	}
@@ -88,9 +97,22 @@ public interface ItemStatConfig extends Config
 		keyName = "absolute",
 		name = "Show absolute",
 		description = "Show absolute stat change in tooltip.",
-		section = sectionGeneral
+		section = sectionGeneral,
+		position = 3
 	)
 	default boolean absolute()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "relative",
+		name = "Show relative",
+		description = "Show relative stat change in tooltip.",
+		section = sectionGeneral,
+		position = 4
+	)
+	default boolean relative()
 	{
 		return true;
 	}
@@ -99,45 +121,69 @@ public interface ItemStatConfig extends Config
 		keyName = "theoretical",
 		name = "Show theoretical",
 		description = "Show theoretical stat change in tooltip.",
-		section = sectionGeneral
+		section = sectionGeneral,
+		position = 5
 	)
 	default boolean theoretical()
 	{
 		return false;
 	}
 
+	/*
+	 * STAT TYPES
+	 */
+
 	@ConfigItem(
-		keyName = "enableWeight",
-		name = "Enable weight",
+		keyName = "consumableStats",
+		name = "Consumables",
+		description = "Enables tooltips for consumable items (food, boosts).",
+		section = sectionStatTypes,
+		position = 0
+	)
+	default ItemStatDisplayType consumableStats()
+	{
+		return ItemStatDisplayType.ALWAYS;
+	}
+
+	@ConfigItem(
+		keyName = "equipmentStats",
+		name = "Equipment",
+		description = "Enables tooltips for equipment items (combat bonuses, weight, prayer bonuses).",
+		section = sectionStatTypes,
+		position = 1
+	)
+	default ItemStatDisplayType equipmentStats()
+	{
+		return ItemStatDisplayType.ALWAYS;
+	}
+
+	@ConfigItem(
+		keyName = "showWeight",
+		name = "Weight",
 		description = "Enable weight in tooltip.",
-		section = sectionGeneral
+		section = sectionStatTypes,
+		position = 2
 	)
-	default boolean showWeight()
+	default ItemStatDisplayType showWeight()
 	{
-		return true;
+		return ItemStatDisplayType.ALWAYS;
 	}
 
 	@ConfigItem(
-		keyName = "showStatsInBank",
-		name = "Show stats in bank",
-		description = "Show item stats on bank items tooltip.",
-		section = sectionGeneral
+		keyName = "modifierKey",
+		name = "Keybind",
+		description = "The key required to display stats in this section, when the respective stat is set to 'On Keybind'",
+		section = sectionStatTypes,
+		position = 3
 	)
-	default boolean showStatsInBank()
+	default Keybind modifierKey()
 	{
-		return true;
+		return Keybind.NOT_SET;
 	}
 
-	@ConfigItem(
-		keyName = "alwaysShowBaseStats",
-		name = "Always show base stats",
-		description = "Always include the base items stats in the tooltip.",
-		section = sectionGeneral
-	)
-	default boolean alwaysShowBaseStats()
-	{
-		return false;
-	}
+	/*
+	 * COLORS
+	 */
 
 	@ConfigItem(
 		keyName = "colorBetterUncapped",
@@ -197,53 +243,5 @@ public interface ItemStatConfig extends Config
 	default Color colorWorse()
 	{
 		return new Color(0xEE3333);
-	}
-
-	@ConfigItem(
-		keyName = "requireModifier",
-		name = "Require modifier key",
-		description = "Require a modifier key to show Item Stats.",
-		section = sectionKeybind,
-		position = 0
-	)
-	default boolean requireModifier()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "requireModifierForConsumables",
-		name = "Require for consumables",
-		description = "Require the key for consumable stats.",
-		section = sectionKeybind,
-		position = 1
-	)
-	default boolean requireModifierForConsumables()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "requireModifierForEquipment",
-		name = "Require for equipment",
-		description = "Require the key for equipment stats.",
-		section = sectionKeybind,
-		position = 2
-	)
-	default boolean requireModifierForEquipment()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "modifierKey",
-		name = "Modifier key",
-		description = "Modifier key for the above option.",
-		section = sectionKeybind,
-		position = 3
-	)
-	default Keybind modifierKey()
-	{
-		return Keybind.NOT_SET;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -25,17 +25,26 @@
 package net.runelite.client.plugins.itemstats;
 
 import java.awt.Color;
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
+
+import net.runelite.client.config.*;
 
 @ConfigGroup("itemstat")
 public interface ItemStatConfig extends Config
 {
+	@ConfigSection(name = "General",         description = "General settings",             position = 0)
+	String sectionGeneral = "general";
+
+	@ConfigSection(name = "Colors",           description = "Color settings",         position = 1)
+	String sectionColors = "colors";
+
+	@ConfigSection(name = "Keybind", description = "Keybind settings",       position = 2)
+	String sectionKeybind = "keybind";
+
 	@ConfigItem(
 		keyName = "consumableStats",
 		name = "Enable consumable stats",
-		description = "Enables tooltips for consumable items (food, boosts)."
+		description = "Enables tooltips for consumable items (food, boosts).",
+		section = sectionGeneral
 	)
 	default boolean consumableStats()
 	{
@@ -45,7 +54,8 @@ public interface ItemStatConfig extends Config
 	@ConfigItem(
 		keyName = "equipmentStats",
 		name = "Enable equipment stats",
-		description = "Enables tooltips for equipment items (combat bonuses, weight, prayer bonuses)."
+		description = "Enables tooltips for equipment items (combat bonuses, weight, prayer bonuses).",
+		section = sectionGeneral
 	)
 	default boolean equipmentStats()
 	{
@@ -55,7 +65,8 @@ public interface ItemStatConfig extends Config
 	@ConfigItem(
 		keyName = "geStats",
 		name = "Enable GE item information",
-		description = "Shows an item information panel when buying items in the GE."
+		description = "Shows an item information panel when buying items in the GE.",
+		section = sectionGeneral
 	)
 	default boolean geStats()
 	{
@@ -65,7 +76,8 @@ public interface ItemStatConfig extends Config
 	@ConfigItem(
 		keyName = "relative",
 		name = "Show relative",
-		description = "Show relative stat change in tooltip."
+		description = "Show relative stat change in tooltip.",
+		section = sectionGeneral
 	)
 	default boolean relative()
 	{
@@ -75,7 +87,8 @@ public interface ItemStatConfig extends Config
 	@ConfigItem(
 		keyName = "absolute",
 		name = "Show absolute",
-		description = "Show absolute stat change in tooltip."
+		description = "Show absolute stat change in tooltip.",
+		section = sectionGeneral
 	)
 	default boolean absolute()
 	{
@@ -85,7 +98,8 @@ public interface ItemStatConfig extends Config
 	@ConfigItem(
 		keyName = "theoretical",
 		name = "Show theoretical",
-		description = "Show theoretical stat change in tooltip."
+		description = "Show theoretical stat change in tooltip.",
+		section = sectionGeneral
 	)
 	default boolean theoretical()
 	{
@@ -95,7 +109,8 @@ public interface ItemStatConfig extends Config
 	@ConfigItem(
 		keyName = "showWeight",
 		name = "Show weight",
-		description = "Show weight in tooltip."
+		description = "Show weight in tooltip.",
+		section = sectionGeneral
 	)
 	default boolean showWeight()
 	{
@@ -105,7 +120,8 @@ public interface ItemStatConfig extends Config
 	@ConfigItem(
 		keyName = "showStatsInBank",
 		name = "Show stats in bank",
-		description = "Show item stats on bank items tooltip."
+		description = "Show item stats on bank items tooltip.",
+		section = sectionGeneral
 	)
 	default boolean showStatsInBank()
 	{
@@ -115,7 +131,8 @@ public interface ItemStatConfig extends Config
 	@ConfigItem(
 		keyName = "alwaysShowBaseStats",
 		name = "Always show base stats",
-		description = "Always include the base items stats in the tooltip."
+		description = "Always include the base items stats in the tooltip.",
+		section = sectionGeneral
 	)
 	default boolean alwaysShowBaseStats()
 	{
@@ -126,7 +143,8 @@ public interface ItemStatConfig extends Config
 		keyName = "colorBetterUncapped",
 		name = "Better (uncapped)",
 		description = "Color to show when the stat change is fully consumed.",
-		position = 10
+			section = sectionColors,
+		position = 0
 	)
 	default Color colorBetterUncapped()
 	{
@@ -137,7 +155,8 @@ public interface ItemStatConfig extends Config
 		keyName = "colorBetterSomecapped",
 		name = "Better (some capped)",
 		description = "Color to show when some stat changes are capped, but some are not.",
-		position = 11
+		section = sectionColors,
+		position = 1
 	)
 	default Color colorBetterSomeCapped()
 	{
@@ -148,7 +167,8 @@ public interface ItemStatConfig extends Config
 		keyName = "colorBetterCapped",
 		name = "Better (capped)",
 		description = "Color to show when the stat change is positive, but not fully consumed.",
-		position = 12
+		section = sectionColors,
+		position = 2
 	)
 	default Color colorBetterCapped()
 	{
@@ -159,7 +179,8 @@ public interface ItemStatConfig extends Config
 		keyName = "colorNoChange",
 		name = "No change",
 		description = "Color to show when there is no change.",
-		position = 13
+		section = sectionColors,
+		position = 3
 	)
 	default Color colorNoChange()
 	{
@@ -170,10 +191,47 @@ public interface ItemStatConfig extends Config
 		keyName = "colorWorse",
 		name = "Worse",
 		description = "Color to show when the stat goes down.",
-		position = 14
+		section = sectionColors,
+		position = 4
 	)
 	default Color colorWorse()
 	{
 		return new Color(0xEE3333);
 	}
+
+	@ConfigItem(
+		keyName = "requireModifier",
+		name = "Require modifier key",
+		description = "Require a modifier key to show Item Stats.",
+		section = sectionKeybind,
+		position = 0
+	)
+	default boolean requireModifier() { return false; }
+
+	@ConfigItem(
+		keyName = "requireModifierForConsumables",
+		name = "Require for consumables",
+		description = "Require the key for consumable stats.",
+		section = sectionKeybind,
+		position = 1
+	)
+	default boolean requireModifierForConsumables() { return false; }
+
+	@ConfigItem(
+		keyName = "requireModifierForEquipment",
+		name = "Require for equipment",
+		description = "Require the key for equipment stats.",
+		section = sectionKeybind,
+		position = 2
+	)
+	default boolean requireModifierForEquipment() { return true; }
+
+	@ConfigItem(
+		keyName = "modifierKey",
+		name = "Modifier key",
+		description = "Modifier key for the above option.",
+		section = sectionKeybind,
+		position = 3
+	)
+	default Keybind modifierKey() { return Keybind.NOT_SET; }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatDisplayType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatDisplayType.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public enum ItemStatDisplayType
 {
-    ALWAYS(),
-    ON_KEYBIND(),
-    NEVER();
+	ALWAYS(),
+	ON_KEYBIND(),
+	NEVER();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatDisplayType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatDisplayType.java
@@ -1,0 +1,15 @@
+package net.runelite.client.plugins.itemstats;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ItemStatDisplayType {
+
+    ALWAYS(),
+    ON_KEYBIND(),
+    NEVER();
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatDisplayType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatDisplayType.java
@@ -1,14 +1,12 @@
 package net.runelite.client.plugins.itemstats;
 
-import java.util.HashMap;
-import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public enum ItemStatDisplayType {
-
+public enum ItemStatDisplayType
+{
     ALWAYS(),
     ON_KEYBIND(),
     NEVER();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -403,9 +403,49 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 	String buildWeightString(ItemStats s)
 	{
 		ItemStats other = null;
+		// Used if switching into a 2 handed weapon to store off-hand stats
 		ItemStats offHand = null;
+		final ItemEquipmentStats currentEquipment = s.getEquipment();
+
+		ItemContainer c = client.getItemContainer(InventoryID.WORN);
+		if (s.isEquipable() && currentEquipment != null && c != null)
+		{
+			final int slot = currentEquipment.getSlot();
+
+			other = getItemStatsFromContainer(c, slot);
+			// Check if this is a shield and there's a two-handed weapon equipped
+			if (other == null && slot == EquipmentInventorySlot.SHIELD.getSlotIdx())
+			{
+				other = getItemStatsFromContainer(c, EquipmentInventorySlot.WEAPON.getSlotIdx());
+				if (other != null)
+				{
+					final ItemEquipmentStats otherEquip = other.getEquipment();
+					if (otherEquip != null)
+					{
+						// Account for speed change when two handed weapon gets removed
+						// shield - (2h - unarmed) == shield - 2h + unarmed
+						other = otherEquip.isTwoHanded() ? subtract(other, UNARMED) : null;
+					}
+				}
+			}
+
+			if (slot == EquipmentInventorySlot.WEAPON.getSlotIdx())
+			{
+				if (other == null)
+				{
+					other = UNARMED;
+				}
+
+				// Get offhand's stats to be removed from equipping a 2h weapon
+				if (currentEquipment.isTwoHanded())
+				{
+					offHand = getItemStatsFromContainer(c, EquipmentInventorySlot.SHIELD.getSlotIdx());
+				}
+			}
+		}
 
 		final ItemStats subtracted = subtract(subtract(s, other), offHand);
+		final ItemEquipmentStats e = subtracted.getEquipment();
 
 		final StringBuilder b = new StringBuilder();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -406,7 +406,6 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 		ItemStats offHand = null;
 
 		final ItemStats subtracted = subtract(subtract(s, other), offHand);
-		final ItemEquipmentStats e = subtracted.getEquipment();
 
 		final StringBuilder b = new StringBuilder();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -88,8 +88,10 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 			return null;
 		}
 
-		if (config.requireModifier()) {
-			if (config.modifierKey().getKeyCode() == Keybind.NOT_SET.getKeyCode()) {
+		if (config.requireModifier())
+		{
+			if (config.modifierKey().getKeyCode() == Keybind.NOT_SET.getKeyCode())
+			{
 				if (config.modifierKey().getModifiers() == 0)
 				{
 					return null;
@@ -212,7 +214,9 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 					tooltipManager.add(new Tooltip(tooltip));
 				}
 			}
-		} else {
+		}
+		else
+		{
 			final ItemStats stats = itemManager.getItemStats(itemId);
 
 			if (stats != null)
@@ -399,9 +403,7 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 	String buildWeightString(ItemStats s)
 	{
 		ItemStats other = null;
-		// Used if switching into a 2 handed weapon to store off-hand stats
 		ItemStats offHand = null;
-		final ItemEquipmentStats currentEquipment = s.getEquipment();
 
 		final ItemStats subtracted = subtract(subtract(s, other), offHand);
 		final ItemEquipmentStats e = subtracted.getEquipment();
@@ -499,23 +501,23 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 	}
 
 	@Override
-	public void keyTyped(KeyEvent e)
+	public void keyTyped(KeyEvent key)
 	{
 	}
 
 	@Override
-	public void keyPressed(KeyEvent e)
+	public void keyPressed(KeyEvent key)
 	{
-		if (config.requireModifier() && config.modifierKey().matches(e))
+		if (config.requireModifier() && config.modifierKey().matches(key))
 		{
 			isKeyPressed = true;
 		}
 	}
 
 	@Override
-	public void keyReleased(KeyEvent e)
+	public void keyReleased(KeyEvent key)
 	{
-		if (config.requireModifier() && config.modifierKey().matches(e))
+		if (config.requireModifier() && config.modifierKey().matches(key))
 		{
 			isKeyPressed = false;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -445,7 +445,6 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 		}
 
 		final ItemStats subtracted = subtract(subtract(s, other), offHand);
-		final ItemEquipmentStats e = subtracted.getEquipment();
 
 		final StringBuilder b = new StringBuilder();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -40,7 +40,6 @@ import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetUtil;
-import net.runelite.client.config.Keybind;
 import net.runelite.client.game.ItemEquipmentStats;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStats;
@@ -370,7 +369,8 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 	}
 
 	@VisibleForTesting
-	String buildWeightString(ItemStats s) {
+	String buildWeightString(ItemStats s)
+	{
 		final StringBuilder b = new StringBuilder();
 
 		ItemStats other = null;
@@ -379,16 +379,20 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 		final ItemEquipmentStats currentEquipment = s.getEquipment();
 
 		ItemContainer c = client.getItemContainer(InventoryID.WORN);
-		if (s.isEquipable() && currentEquipment != null && c != null) {
+		if (s.isEquipable() && currentEquipment != null && c != null)
+		{
 			final int slot = currentEquipment.getSlot();
 
 			other = getItemStatsFromContainer(c, slot);
 			// Check if this is a shield and there's a two-handed weapon equipped
-			if (other == null && slot == EquipmentInventorySlot.SHIELD.getSlotIdx()) {
+			if (other == null && slot == EquipmentInventorySlot.SHIELD.getSlotIdx())
+			{
 				other = getItemStatsFromContainer(c, EquipmentInventorySlot.WEAPON.getSlotIdx());
-				if (other != null) {
+				if (other != null)
+				{
 					final ItemEquipmentStats otherEquip = other.getEquipment();
-					if (otherEquip != null) {
+					if (otherEquip != null)
+					{
 						// Account for speed change when two handed weapon gets removed
 						// shield - (2h - unarmed) == shield - 2h + unarmed
 						other = otherEquip.isTwoHanded() ? subtract(other, UNARMED) : null;
@@ -396,13 +400,16 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 				}
 			}
 
-			if (slot == EquipmentInventorySlot.WEAPON.getSlotIdx()) {
-				if (other == null) {
+			if (slot == EquipmentInventorySlot.WEAPON.getSlotIdx())
+			{
+				if (other == null)
+				{
 					other = UNARMED;
 				}
 
 				// Get offhand's stats to be removed from equipping a 2h weapon
-				if (currentEquipment.isTwoHanded()) {
+				if (currentEquipment.isTwoHanded())
+				{
 					offHand = getItemStatsFromContainer(c, EquipmentInventorySlot.SHIELD.getSlotIdx());
 				}
 			}
@@ -504,8 +511,10 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent key)
 	{
-		if (config.consumableStats().equals(ItemStatDisplayType.ON_KEYBIND) || config.equipmentStats().equals(ItemStatDisplayType.ON_KEYBIND) || config.showWeight().equals(ItemStatDisplayType.ON_KEYBIND)) {
-			if (config.modifierKey().matches(key)) {
+		if (config.consumableStats().equals(ItemStatDisplayType.ON_KEYBIND) || config.equipmentStats().equals(ItemStatDisplayType.ON_KEYBIND) || config.showWeight().equals(ItemStatDisplayType.ON_KEYBIND))
+		{
+			if (config.modifierKey().matches(key))
+			{
 				isKeyPressed = true;
 			}
 		}
@@ -514,8 +523,10 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 	@Override
 	public void keyReleased(KeyEvent key)
 	{
-		if (config.consumableStats().equals(ItemStatDisplayType.ON_KEYBIND) || config.equipmentStats().equals(ItemStatDisplayType.ON_KEYBIND) || config.showWeight().equals(ItemStatDisplayType.ON_KEYBIND)) {
-			if (config.modifierKey().matches(key)) {
+		if (config.consumableStats().equals(ItemStatDisplayType.ON_KEYBIND) || config.equipmentStats().equals(ItemStatDisplayType.ON_KEYBIND) || config.showWeight().equals(ItemStatDisplayType.ON_KEYBIND))
+		{
+			if (config.modifierKey().matches(key))
+			{
 				isKeyPressed = false;
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -29,6 +29,7 @@ import com.google.inject.Inject;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.event.KeyEvent;
 import java.time.Duration;
 import net.runelite.api.Client;
 import net.runelite.api.EquipmentInventorySlot;
@@ -39,9 +40,11 @@ import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetUtil;
+import net.runelite.client.config.Keybind;
 import net.runelite.client.game.ItemEquipmentStats;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStats;
+import net.runelite.client.input.KeyListener;
 import net.runelite.client.plugins.itemstats.potions.PotionDuration;
 import net.runelite.client.ui.JagexColors;
 import net.runelite.client.ui.overlay.Overlay;
@@ -51,7 +54,7 @@ import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.QuantityFormatter;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 
-public class ItemStatOverlay extends Overlay
+public class ItemStatOverlay extends Overlay implements KeyListener
 {
 	// Unarmed attack speed is 4
 	@VisibleForTesting
@@ -75,12 +78,23 @@ public class ItemStatOverlay extends Overlay
 	@Inject
 	private ItemStatConfig config;
 
+	private boolean isKeyPressed;
+
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
 		if (client.isMenuOpen() || (!config.relative() && !config.absolute() && !config.theoretical()))
 		{
 			return null;
+		}
+
+		if (config.requireModifier()) {
+			if (config.modifierKey().getKeyCode() == Keybind.NOT_SET.getKeyCode()) {
+				if (config.modifierKey().getModifiers() == 0)
+				{
+					return null;
+				}
+			}
 		}
 
 		final MenuEntry[] menu = client.getMenuEntries();
@@ -125,7 +139,7 @@ public class ItemStatOverlay extends Overlay
 			return null;
 		}
 
-		if (config.consumableStats())
+		if (config.consumableStats() && ((config.requireModifierForConsumables() && isKeyPressed) || !config.requireModifier() || !config.requireModifierForConsumables()))
 		{
 			final Effect change = statChanges.get(itemId);
 			if (change != null)
@@ -185,13 +199,25 @@ public class ItemStatOverlay extends Overlay
 			}
 		}
 
-		if (config.equipmentStats())
+		if (config.equipmentStats() && ((config.requireModifierForEquipment() && isKeyPressed) || !config.requireModifier() || !config.requireModifierForEquipment()))
 		{
 			final ItemStats stats = itemManager.getItemStats(itemId);
 
 			if (stats != null)
 			{
 				final String tooltip = buildStatBonusString(stats);
+
+				if (!tooltip.isEmpty())
+				{
+					tooltipManager.add(new Tooltip(tooltip));
+				}
+			}
+		} else {
+			final ItemStats stats = itemManager.getItemStats(itemId);
+
+			if (stats != null)
+			{
+				final String tooltip = buildWeightString(stats);
 
 				if (!tooltip.isEmpty())
 				{
@@ -369,6 +395,28 @@ public class ItemStatOverlay extends Overlay
 		return b.toString();
 	}
 
+	@VisibleForTesting
+	String buildWeightString(ItemStats s)
+	{
+		ItemStats other = null;
+		// Used if switching into a 2 handed weapon to store off-hand stats
+		ItemStats offHand = null;
+		final ItemEquipmentStats currentEquipment = s.getEquipment();
+
+		final ItemStats subtracted = subtract(subtract(s, other), offHand);
+		final ItemEquipmentStats e = subtracted.getEquipment();
+
+		final StringBuilder b = new StringBuilder();
+
+		if (config.showWeight())
+		{
+			double sw = config.alwaysShowBaseStats() ? subtracted.getWeight() : s.getWeight();
+			b.append(buildStatRow("Weight", s.getWeight(), sw, true, false, s.isEquipable()));
+		}
+
+		return b.toString();
+	}
+
 	private static ItemStats subtract(ItemStats one, ItemStats two)
 	{
 		if (two == null)
@@ -448,5 +496,28 @@ public class ItemStatOverlay extends Overlay
 		b.append("</br>");
 
 		return b.toString();
+	}
+
+	@Override
+	public void keyTyped(KeyEvent e)
+	{
+	}
+
+	@Override
+	public void keyPressed(KeyEvent e)
+	{
+		if (config.requireModifier() && config.modifierKey().matches(e))
+		{
+			isKeyPressed = true;
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent e)
+	{
+		if (config.requireModifier() && config.modifierKey().matches(e))
+		{
+			isKeyPressed = false;
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -88,17 +88,6 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 			return null;
 		}
 
-		if (config.requireModifier())
-		{
-			if (config.modifierKey().getKeyCode() == Keybind.NOT_SET.getKeyCode())
-			{
-				if (config.modifierKey().getModifiers() == 0)
-				{
-					return null;
-				}
-			}
-		}
-
 		final MenuEntry[] menu = client.getMenuEntries();
 		final int menuSize = menu.length;
 		if (menuSize <= 0)
@@ -141,7 +130,7 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 			return null;
 		}
 
-		if (config.consumableStats() && ((config.requireModifierForConsumables() && isKeyPressed) || !config.requireModifier() || !config.requireModifierForConsumables()))
+		if (config.consumableStats().equals(ItemStatDisplayType.ALWAYS) || (config.consumableStats().equals(ItemStatDisplayType.ON_KEYBIND) && isKeyPressed))
 		{
 			final Effect change = statChanges.get(itemId);
 			if (change != null)
@@ -201,7 +190,7 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 			}
 		}
 
-		if (config.equipmentStats() && ((config.requireModifierForEquipment() && isKeyPressed) || !config.requireModifier() || !config.requireModifierForEquipment()))
+		if (config.equipmentStats().equals(ItemStatDisplayType.ALWAYS) || (config.equipmentStats().equals(ItemStatDisplayType.ON_KEYBIND) && isKeyPressed))
 		{
 			final ItemStats stats = itemManager.getItemStats(itemId);
 
@@ -215,7 +204,8 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 				}
 			}
 		}
-		else
+
+		if (config.showWeight().equals(ItemStatDisplayType.ALWAYS) || (config.showWeight().equals(ItemStatDisplayType.ON_KEYBIND) && isKeyPressed))
 		{
 			final ItemStats stats = itemManager.getItemStats(itemId);
 
@@ -233,10 +223,7 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 		return null;
 	}
 
-	private String getChangeString(
-		final double value,
-		final boolean inverse,
-		final boolean showPercent)
+	private String getChangeString(final double value, final boolean inverse, final boolean showPercent)
 	{
 		final Color plus = Positivity.getColor(config, Positivity.BETTER_UNCAPPED);
 		final Color minus = Positivity.getColor(config, Positivity.WORSE);
@@ -263,23 +250,12 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 		return ColorUtil.wrapWithColorTag(prefix + valueString + suffix, color);
 	}
 
-	private String buildStatRow(
-		final String label,
-		final double value,
-		final double diffValue,
-		final boolean inverse,
-		final boolean showPercent)
+	private String buildStatRow(final String label, final double value, final double diffValue, final boolean inverse, final boolean showPercent)
 	{
 		return buildStatRow(label, value, diffValue, inverse, showPercent, true);
 	}
 
-	private String buildStatRow(
-		final String label,
-		final double value,
-		final double diffValue,
-		final boolean inverse,
-		final boolean showPercent,
-		final boolean showBase)
+	private String buildStatRow(final String label, final double value, final double diffValue, final boolean inverse, final boolean showPercent, final boolean showBase)
 	{
 		final StringBuilder b = new StringBuilder();
 
@@ -357,12 +333,6 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 
 		final StringBuilder b = new StringBuilder();
 
-		if (config.showWeight())
-		{
-			double sw = config.alwaysShowBaseStats() ? subtracted.getWeight() : s.getWeight();
-			b.append(buildStatRow("Weight", s.getWeight(), sw, true, false, s.isEquipable()));
-		}
-
 		if (subtracted.isEquipable() && e != null)
 		{
 			b.append(buildStatRow("Prayer", currentEquipment.getPrayer(), e.getPrayer(), false, false));
@@ -400,28 +370,25 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 	}
 
 	@VisibleForTesting
-	String buildWeightString(ItemStats s)
-	{
+	String buildWeightString(ItemStats s) {
+		final StringBuilder b = new StringBuilder();
+
 		ItemStats other = null;
 		// Used if switching into a 2 handed weapon to store off-hand stats
 		ItemStats offHand = null;
 		final ItemEquipmentStats currentEquipment = s.getEquipment();
 
 		ItemContainer c = client.getItemContainer(InventoryID.WORN);
-		if (s.isEquipable() && currentEquipment != null && c != null)
-		{
+		if (s.isEquipable() && currentEquipment != null && c != null) {
 			final int slot = currentEquipment.getSlot();
 
 			other = getItemStatsFromContainer(c, slot);
 			// Check if this is a shield and there's a two-handed weapon equipped
-			if (other == null && slot == EquipmentInventorySlot.SHIELD.getSlotIdx())
-			{
+			if (other == null && slot == EquipmentInventorySlot.SHIELD.getSlotIdx()) {
 				other = getItemStatsFromContainer(c, EquipmentInventorySlot.WEAPON.getSlotIdx());
-				if (other != null)
-				{
+				if (other != null) {
 					final ItemEquipmentStats otherEquip = other.getEquipment();
-					if (otherEquip != null)
-					{
+					if (otherEquip != null) {
 						// Account for speed change when two handed weapon gets removed
 						// shield - (2h - unarmed) == shield - 2h + unarmed
 						other = otherEquip.isTwoHanded() ? subtract(other, UNARMED) : null;
@@ -429,16 +396,13 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 				}
 			}
 
-			if (slot == EquipmentInventorySlot.WEAPON.getSlotIdx())
-			{
-				if (other == null)
-				{
+			if (slot == EquipmentInventorySlot.WEAPON.getSlotIdx()) {
+				if (other == null) {
 					other = UNARMED;
 				}
 
 				// Get offhand's stats to be removed from equipping a 2h weapon
-				if (currentEquipment.isTwoHanded())
-				{
+				if (currentEquipment.isTwoHanded()) {
 					offHand = getItemStatsFromContainer(c, EquipmentInventorySlot.SHIELD.getSlotIdx());
 				}
 			}
@@ -446,14 +410,8 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 
 		final ItemStats subtracted = subtract(subtract(s, other), offHand);
 
-		final StringBuilder b = new StringBuilder();
-
-		if (config.showWeight())
-		{
-			double sw = config.alwaysShowBaseStats() ? subtracted.getWeight() : s.getWeight();
-			b.append(buildStatRow("Weight", s.getWeight(), sw, true, false, s.isEquipable()));
-		}
-
+		double sw = config.alwaysShowBaseStats() ? subtracted.getWeight() : s.getWeight();
+		b.append(buildStatRow("Weight", s.getWeight(), sw, true, false, s.isEquipable()));
 		return b.toString();
 	}
 
@@ -546,18 +504,20 @@ public class ItemStatOverlay extends Overlay implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent key)
 	{
-		if (config.requireModifier() && config.modifierKey().matches(key))
-		{
-			isKeyPressed = true;
+		if (config.consumableStats().equals(ItemStatDisplayType.ON_KEYBIND) || config.equipmentStats().equals(ItemStatDisplayType.ON_KEYBIND) || config.showWeight().equals(ItemStatDisplayType.ON_KEYBIND)) {
+			if (config.modifierKey().matches(key)) {
+				isKeyPressed = true;
+			}
 		}
 	}
 
 	@Override
 	public void keyReleased(KeyEvent key)
 	{
-		if (config.requireModifier() && config.modifierKey().matches(key))
-		{
-			isKeyPressed = false;
+		if (config.consumableStats().equals(ItemStatDisplayType.ON_KEYBIND) || config.equipmentStats().equals(ItemStatDisplayType.ON_KEYBIND) || config.showWeight().equals(ItemStatDisplayType.ON_KEYBIND)) {
+			if (config.modifierKey().matches(key)) {
+				isKeyPressed = false;
+			}
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
@@ -59,6 +59,7 @@ import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.ItemEquipmentStats;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStats;
+import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.FontManager;
@@ -94,6 +95,8 @@ public class ItemStatPlugin extends Plugin
 
 	@Inject
 	private ClientThread clientThread;
+	@Inject
+	private KeyManager keyManager;
 
 	private Widget itemInformationTitle;
 
@@ -112,12 +115,14 @@ public class ItemStatPlugin extends Plugin
 	@Override
 	protected void startUp() throws Exception
 	{
+		keyManager.registerKeyListener(overlay);
 		overlayManager.add(overlay);
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
+		keyManager.unregisterKeyListener(overlay);
 		overlayManager.remove(overlay);
 		clientThread.invokeLater(this::resetGEInventory);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
@@ -95,14 +95,22 @@ public class ItemStatPlugin extends Plugin
 
 	@Inject
 	private ClientThread clientThread;
+
 	@Inject
 	private KeyManager keyManager;
+
+	@Inject
+	private ConfigManager configManager;
 
 	private Widget itemInformationTitle;
 
 	@Provides
 	ItemStatConfig getConfig(ConfigManager configManager)
 	{
+		migrateBooleanConfig(configManager, "consumableStats");
+		migrateBooleanConfig(configManager, "equipmentStats");
+		migrateBooleanConfig(configManager, "showWeight");
+
 		return configManager.getConfig(ItemStatConfig.class);
 	}
 
@@ -430,6 +438,20 @@ public class ItemStatPlugin extends Plugin
 		else
 		{
 			return client.getWidget(InterfaceID.Toplevel.SIDE3);
+		}
+	}
+
+	private static void migrateBooleanConfig(ConfigManager configManager, String key)
+	{
+		final String value = configManager.getConfiguration("itemstat", key);
+
+		if ("true".equalsIgnoreCase(value))
+		{
+			configManager.setConfiguration("itemstat", key, ItemStatDisplayType.ALWAYS);
+		}
+		else if ("false".equalsIgnoreCase(value))
+		{
+			configManager.setConfiguration("itemstat", key, ItemStatDisplayType.NEVER);
 		}
 	}
 }


### PR DESCRIPTION
Update to the Item Stats plugin - includes the following:
- Configuration categories.
- Decoupled weight overlay from Equipment Stats config option (weight would not show if **Enable equipment stats** option was not checked, despite the **Enable weight** option being separate)
- Added Keybind Category:
  - Allows users to choose whether a configurable keybind is required to display the overlay
  - Includes option to choose whether this is required for Consumables or Equipment separately.

Also in the process of updating this, this plugin now works with new items such as the Hallowfell sword.

<img width="252" height="779" alt="image" src="https://github.com/user-attachments/assets/c76a3c51-8ae3-45ec-ba13-03e01e870b79" />

<img width="222" height="380" alt="image" src="https://github.com/user-attachments/assets/4cbcf54a-617a-4e05-8da3-7514ee988534" />
