### PR TITLE
timers: fix freeze chat message parsing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -99,7 +99,7 @@ public class TimersAndBuffsPlugin extends Plugin
 	private static final String CANNON_REPAIR_MESSAGE = "You repair your cannon, restoring it to working order.";
 	private static final String CANNON_DESTROYED_MESSAGE = "Your cannon has been destroyed!";
 	private static final String CANNON_BROKEN_MESSAGE = "<col=ef1020>Your cannon has broken!";
-	private static final String FROZEN_MESSAGE = "@mes_hl_red@You have been frozen!</col>";
+	private static final String FROZEN_MESSAGE = "You have been frozen!</col>";
 	private static final String STAFF_OF_THE_DEAD_SPEC_EXPIRED_MESSAGE = "Your protection fades away";
 	private static final String STAFF_OF_THE_DEAD_SPEC_MESSAGE = "Spirits of deceased evildoers offer you their protection";
 	private static final String PRAYER_ENHANCE_EXPIRED = "<col=ff0000>Your prayer enhance effect has worn off.</col>";
@@ -1010,7 +1010,7 @@ public class TimersAndBuffsPlugin extends Plugin
 			removeGameTimer(STAFF_OF_THE_DEAD);
 		}
 
-		if (message.equals(FROZEN_MESSAGE) && config.showFreezes())
+		if (message.endsWith(FROZEN_MESSAGE) && config.showFreezes())
 		{
 			freezeTimer = createGameTimer(ICEBARRAGE);
 			freezeTime = client.getTickCount();

--- a/runelite-client/src/test/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPluginTest.java
@@ -223,6 +223,32 @@ public class TimersAndBuffsPluginTest
 	}
 
 	@Test
+	public void testFreezeTimerOldFormat()
+	{
+		when(timersAndBuffsConfig.showFreezes()).thenReturn(true);
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "<col=ef1020>You have been frozen!</col>", "", 0);
+		timersAndBuffsPlugin.onChatMessage(chatMessage);
+
+		ArgumentCaptor<InfoBox> captor = ArgumentCaptor.forClass(InfoBox.class);
+		verify(infoBoxManager).addInfoBox(captor.capture());
+		TimerTimer infoBox = (TimerTimer) captor.getValue();
+		assertEquals(GameTimer.ICEBARRAGE, infoBox.getTimer());
+	}
+
+	@Test
+	public void testFreezeTimerNewFormat()
+	{
+		when(timersAndBuffsConfig.showFreezes()).thenReturn(true);
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "@mes_hl_red@You have been frozen!</col>", "", 0);
+		timersAndBuffsPlugin.onChatMessage(chatMessage);
+
+		ArgumentCaptor<InfoBox> captor = ArgumentCaptor.forClass(InfoBox.class);
+		verify(infoBoxManager).addInfoBox(captor.capture());
+		TimerTimer infoBox = (TimerTimer) captor.getValue();
+		assertEquals(GameTimer.ICEBARRAGE, infoBox.getTimer());
+	}
+
+	@Test
 	public void testTzhaarTimer()
 	{
 		when(timersAndBuffsConfig.showTzhaarTimers()).thenReturn(true);


### PR DESCRIPTION
The freeze timer currently matches the full formatted freeze message with an exact string comparison.

The recent chat macro update changed the formatting representation of the message, while the timer check remained coupled to that exact representation.

This changes the freeze detection to match the stable message suffix with endsWith(), consistent with similar formatted message parsing already used in TimersAndBuffsPlugin.

Added regression coverage for both the previous <col=...> format and the newer @mes_hl_red@ format.