### PR TITLE
Add key event interceptors

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/input/KeyEventInterceptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/input/KeyEventInterceptor.java
@@ -1,0 +1,23 @@
+package net.runelite.client.input;
+
+import java.awt.event.KeyEvent;
+
+@FunctionalInterface
+public interface KeyEventInterceptor
+{
+	default boolean isEnabledOnLoginScreen()
+	{
+		return false;
+	}
+
+	/**
+	 * Intercept a key event before it is dispatched to {@link KeyListener}s.
+	 * Returning {@code true} stops listener dispatch without consuming the AWT
+	 * event. Call {@link KeyEvent#consume()} when the event should also be
+	 * blocked from the game client.
+	 *
+	 * @param event the key event
+	 * @return true to stop dispatch to key listeners
+	 */
+	boolean intercept(KeyEvent event);
+}

--- a/runelite-client/src/main/java/net/runelite/client/input/KeyManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/input/KeyManager.java
@@ -51,6 +51,25 @@ public class KeyManager
 	}
 
 	private final List<KeyListener> keyListeners = new CopyOnWriteArrayList<>();
+	private final List<KeyEventInterceptor> keyEventInterceptors = new CopyOnWriteArrayList<>();
+
+	public void registerKeyEventInterceptor(KeyEventInterceptor keyEventInterceptor)
+	{
+		if (!keyEventInterceptors.contains(keyEventInterceptor))
+		{
+			log.debug("Registering key event interceptor: {}", keyEventInterceptor);
+			keyEventInterceptors.add(keyEventInterceptor);
+		}
+	}
+
+	public void unregisterKeyEventInterceptor(KeyEventInterceptor keyEventInterceptor)
+	{
+		final boolean unregistered = keyEventInterceptors.remove(keyEventInterceptor);
+		if (unregistered)
+		{
+			log.debug("Unregistered key event interceptor: {}", keyEventInterceptor);
+		}
+	}
 
 	public void registerKeyListener(KeyListener keyListener)
 	{
@@ -72,7 +91,7 @@ public class KeyManager
 
 	public void processKeyPressed(KeyEvent keyEvent)
 	{
-		if (keyEvent.isConsumed())
+		if (keyEvent.isConsumed() || intercept(keyEvent))
 		{
 			return;
 		}
@@ -97,7 +116,7 @@ public class KeyManager
 
 	public void processKeyReleased(KeyEvent keyEvent)
 	{
-		if (keyEvent.isConsumed())
+		if (keyEvent.isConsumed() || intercept(keyEvent))
 		{
 			return;
 		}
@@ -122,7 +141,7 @@ public class KeyManager
 
 	public void processKeyTyped(KeyEvent keyEvent)
 	{
-		if (keyEvent.isConsumed())
+		if (keyEvent.isConsumed() || intercept(keyEvent))
 		{
 			return;
 		}
@@ -143,6 +162,41 @@ public class KeyManager
 				break;
 			}
 		}
+	}
+
+	private boolean intercept(final KeyEvent keyEvent)
+	{
+		for (KeyEventInterceptor keyEventInterceptor : keyEventInterceptors)
+		{
+			if (!shouldProcess(keyEventInterceptor))
+			{
+				continue;
+			}
+
+			if (keyEventInterceptor.intercept(keyEvent) || keyEvent.isConsumed())
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean shouldProcess(final KeyEventInterceptor keyEventInterceptor)
+	{
+		if (client == null)
+		{
+			return true;
+		}
+
+		final GameState gameState = client.getGameState();
+
+		if (gameState == GameState.LOGIN_SCREEN || gameState == GameState.LOGIN_SCREEN_AUTHENTICATOR)
+		{
+			return keyEventInterceptor.isEnabledOnLoginScreen();
+		}
+
+		return true;
 	}
 
 	private boolean shouldProcess(final KeyListener keyListener)

--- a/runelite-client/src/test/java/net/runelite/client/input/KeyManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/input/KeyManagerTest.java
@@ -1,0 +1,77 @@
+package net.runelite.client.input;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.awt.Canvas;
+import java.awt.event.KeyEvent;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.client.eventbus.EventBus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KeyManagerTest
+{
+	@Inject
+	private KeyManager keyManager;
+
+	@Mock
+	@Bind
+	private Client client;
+
+	@Mock
+	@Bind
+	private EventBus eventBus;
+
+	@Mock
+	private KeyListener keyListener;
+
+	@Before
+	public void setUp()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+
+		keyManager.registerKeyListener(keyListener);
+	}
+
+	@Test
+	public void testInterceptorStopsListenerDispatchWithoutConsumingEvent()
+	{
+		KeyEvent event = keyEvent(KeyEvent.KEY_PRESSED);
+		keyManager.registerKeyEventInterceptor(e -> true);
+
+		keyManager.processKeyPressed(event);
+
+		verify(keyListener, never()).keyPressed(event);
+		assertFalse(event.isConsumed());
+	}
+
+	@Test
+	public void testInterceptorPassesEventThrough()
+	{
+		KeyEvent event = keyEvent(KeyEvent.KEY_PRESSED);
+		keyManager.registerKeyEventInterceptor(e -> false);
+
+		keyManager.processKeyPressed(event);
+
+		verify(keyListener).keyPressed(event);
+		assertFalse(event.isConsumed());
+	}
+
+	private static KeyEvent keyEvent(int id)
+	{
+		return new KeyEvent(new Canvas(), id, 0, 0, KeyEvent.VK_A, 'a');
+	}
+}


### PR DESCRIPTION
Adds a minimal KeyManager hook that lets keybound keys be typed in chat without triggering their plugin keybinds

Solves this pr in a more minimalistic way : https://github.com/runelite/runelite/pull/20321