### PR TITLE
slayer: correct mortimer initial count on login

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -328,7 +328,10 @@ public class SlayerPlugin extends Plugin
 			|| varpId == VarPlayerID.SLAYER_AREA
 			|| varpId == VarPlayerID.SLAYER_TARGET
 			|| varbitId == VarbitID.SLAYER_TARGET_BOSSID
-			|| varpId == VarPlayerID.SLAYER_COUNT_ORIGINAL)
+			|| varpId == VarPlayerID.SLAYER_COUNT_ORIGINAL
+			|| varbitId == VarbitID.SLAYER_MODIFIER_ID
+			|| varbitId == VarbitID.SLAYER_MODIFIER_VALUE
+			|| varbitId == VarbitID.SLAYER_MODIFIER_NEGATIVE)
 		{
 			clientThread.invokeLater(this::updateTask);
 		}


### PR DESCRIPTION
Mortimer varbits are set after SLAYER_COUNT which caused the configManager initialAmount to be set to the unmodified amount on login.
```
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.c.plugins.slayer.SlayerPlugin - Tick: 0 VarPlayerID.SLAYER_COUNT changed, new value: 35
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.c.plugins.slayer.SlayerPlugin - Tick: 0 VarPlayerID.SLAYER_TARGET changed, new value: 38
2026-09-03 12:24:10 PDT [Client] INFO  n.r.c.plugins.slayer.SlayerPlugin - updateTask tick=0 loginFlag=true count=35 original=0 modifierId=0 modifierValue=0 negative=0
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.c.plugins.slayer.SlayerPlugin - Sync slayer task: 35x Banshees at null
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.client.config.ConfigManager - Setting configuration value for slayer.rsprofile.nspMVYP3.initialAmount to 0
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.client.config.ConfigManager - Setting configuration value for slayer.rsprofile.nspMVYP3.points to 0
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.client.config.ConfigManager - Setting configuration value for slayer.rsprofile.nspMVYP3.streak to 0
2026-09-03 12:24:10 PDT [Client] INFO  n.r.c.plugins.slayer.SlayerPlugin - updateTask tick=0 loginFlag=true count=35 original=0 modifierId=0 modifierValue=0 negative=0
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.c.plugins.slayer.SlayerPlugin - Sync slayer task: 35x Banshees at null
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.client.config.ConfigManager - Setting configuration value for slayer.rsprofile.nspMVYP3.points to 265
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.c.plugins.slayer.SlayerPlugin - Tick: 0 VarbitID.SLAYER_POINTS changed, new value: 265
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.client.config.ConfigManager - Setting configuration value for slayer.rsprofile.nspMVYP3.streak to 112
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.c.plugins.slayer.SlayerPlugin - Tick: 0 VarbitID.SLAYER_TASKS_COMPLETED changed, new value: 112
2026-09-03 12:24:10 PDT [Client] INFO  n.r.c.plugins.slayer.SlayerPlugin - updateTask tick=0 loginFlag=true count=35 original=50 modifierId=0 modifierValue=0 negative=0
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.c.plugins.slayer.SlayerPlugin - Sync slayer task: 35x Banshees at null
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.client.config.ConfigManager - Setting configuration value for slayer.rsprofile.nspMVYP3.initialAmount to 50
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.c.plugins.slayer.SlayerPlugin - Tick: 0 VarbitID.SLAYER_MODIFIER_ID changed, new value: 2
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.c.plugins.slayer.SlayerPlugin - Tick: 0 VarbitID.SLAYER_MODIFIER_VALUE changed, new value: 15
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.c.plugins.slayer.SlayerPlugin - Tick: 0 VarbitID.SLAYER_MODIFIER_NEGATIVE changed, new value: 1
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.client.config.ConfigManager - Setting configuration value for slayer.rsprofile.nspMVYP3.streak to 3
2026-09-03 12:24:10 PDT [Client] DEBUG n.r.c.plugins.slayer.SlayerPlugin - Tick: 0 VarPlayerID.SLAYER_MORTIMER_TASKS_COMPLETED changed, new value: 3
```

By triggering updateTask on the Mortimer modifiers the initialAmount is correctly set to 35.
```
2026-09-03 12:31:49 PDT [Client] DEBUG n.r.c.plugins.slayer.SlayerPlugin - Sync slayer task: 35x Banshees at null
2026-09-03 12:31:49 PDT [Client] DEBUG n.r.client.config.ConfigManager - Setting configuration value for slayer.rsprofile.nspMVYP3.initialAmount to 35
```