### PR TITLE
Performance optimizations for GPU sorting, geometry, ground items, and cache processing

### DIFF
--- a/cache/src/main/java/net/runelite/cache/fs/Archive.java
+++ b/cache/src/main/java/net/runelite/cache/fs/Archive.java
@@ -43,7 +43,6 @@ public class Archive
 	@Getter
 	private final int archiveId;
 	@Getter
-	@Setter
 	private int nameHash;
 	@Getter
 	@Setter
@@ -68,6 +67,18 @@ public class Archive
 	{
 		this.index = index;
 		this.archiveId = id;
+	}
+
+	public void setNameHash(int nameHash)
+	{
+		if (this.nameHash != nameHash)
+		{
+			this.nameHash = nameHash;
+			if (index != null)
+			{
+				index.invalidateNameCache();
+			}
+		}
 	}
 
 	public byte[] decompress(byte[] data) throws IOException

--- a/cache/src/main/java/net/runelite/cache/fs/ArchiveFiles.java
+++ b/cache/src/main/java/net/runelite/cache/fs/ArchiveFiles.java
@@ -89,8 +89,8 @@ public class ArchiveFiles
 		int chunks = stream.readUnsignedByte();
 
 		// -1 for chunks count + one int per file slot per chunk
-		stream.setOffset(stream.getLength() - 1 - chunks * filesCount * 4);
-		int[][] chunkSizes = new int[filesCount][chunks];
+		int chunkTableOffset = stream.getLength() - 1 - chunks * filesCount * 4;
+		stream.setOffset(chunkTableOffset);
 		int[] filesSize = new int[filesCount];
 
 		for (int chunk = 0; chunk < chunks; ++chunk)
@@ -101,8 +101,6 @@ public class ArchiveFiles
 			{
 				int delta = stream.readInt();
 				chunkSize += delta; // size of this chunk
-
-				chunkSizes[id][chunk] = chunkSize; // store size of chunk
 
 				filesSize[id] += chunkSize; // add chunk size to file size
 			}
@@ -116,17 +114,20 @@ public class ArchiveFiles
 			fileContents[i] = new byte[filesSize[i]];
 		}
 
-		// the file data is at the beginning of the stream
-		stream.setOffset(0);
+		// Read the chunk table again instead of allocating a size array for every file.
+		stream.setOffset(chunkTableOffset);
+		int dataOffset = 0;
 
 		for (int chunk = 0; chunk < chunks; ++chunk)
 		{
+			int chunkSize = 0;
 			for (int id = 0; id < filesCount; ++id)
 			{
-				int chunkSize = chunkSizes[id][chunk];
+				chunkSize += stream.readInt();
 
-				stream.readBytes(fileContents[id], fileOffsets[id], chunkSize);
+				System.arraycopy(data, dataOffset, fileContents[id], fileOffsets[id], chunkSize);
 
+				dataOffset += chunkSize;
 				fileOffsets[id] += chunkSize;
 			}
 		}
@@ -141,9 +142,13 @@ public class ArchiveFiles
 
 	public byte[] saveContents()
 	{
-		OutputStream stream = new OutputStream();
-
 		int filesCount = this.getFiles().size();
+		int size = filesCount == 1 ? 0 : filesCount * Integer.BYTES + 1;
+		for (FSFile file : files.values())
+		{
+			size = Math.addExact(size, file.getSize());
+		}
+		OutputStream stream = new OutputStream(size);
 
 		if (filesCount == 1)
 		{
@@ -172,7 +177,8 @@ public class ArchiveFiles
 			stream.writeByte(1); // chunks
 		}
 
-		byte[] fileData = stream.flip();
+		// The exact-size buffer belongs to this result; no final copy is necessary.
+		byte[] fileData = stream.getArray();
 
 		logger.trace("Saved contents of archive ({} files), {} bytes", files.size(), fileData.length);
 		return fileData;

--- a/cache/src/main/java/net/runelite/cache/fs/Index.java
+++ b/cache/src/main/java/net/runelite/cache/fs/Index.java
@@ -26,7 +26,9 @@ package net.runelite.cache.fs;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -61,6 +63,7 @@ public class Index
 	private int compression; // compression method of this index's data in 255
 
 	private final List<Archive> archives = new ArrayList<>();
+	private volatile Map<Integer, Archive> archivesByName;
 
 	public Index(int id)
 	{
@@ -83,6 +86,7 @@ public class Index
 		idx = -idx - 1;
 		Archive archive = new Archive(this, id);
 		this.archives.add(idx, archive);
+		invalidateNameCache();
 		return archive;
 	}
 
@@ -127,20 +131,34 @@ public class Index
 
 	public boolean removeArchive(Archive archive)
 	{
-		return archives.remove(archive);
+		boolean removed = archives.remove(archive);
+		if (removed)
+		{
+			invalidateNameCache();
+		}
+		return removed;
 	}
 
 	public Archive findArchiveByName(String name)
 	{
 		int hash = Djb2.hash(name);
-		for (Archive a : archives)
+		Map<Integer, Archive> byName = archivesByName;
+		if (byName == null)
 		{
-			if (a.getNameHash() == hash)
+			byName = new HashMap<>();
+			for (Archive archive : archives)
 			{
-				return a;
+				// Archives are ordered by id. Preserve the first match for duplicate hashes.
+				byName.putIfAbsent(archive.getNameHash(), archive);
 			}
+			archivesByName = byName;
 		}
-		return null;
+		return byName.get(hash);
+	}
+
+	void invalidateNameCache()
+	{
+		archivesByName = null;
 	}
 
 	public IndexData toIndexData()

--- a/cache/src/test/java/net/runelite/cache/fs/ArchiveFilesTest.java
+++ b/cache/src/test/java/net/runelite/cache/fs/ArchiveFilesTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.cache.fs;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotSame;
+import org.junit.Test;
+
+public class ArchiveFilesTest
+{
+	@Test
+	public void testSingleFileIsCopiedWhenSaved()
+	{
+		byte[] contents = {1, 2, 3};
+		ArchiveFiles files = new ArchiveFiles();
+		addFile(files, 10, contents);
+		byte[] saved = files.saveContents();
+		assertArrayEquals(contents, saved);
+		assertNotSame(contents, saved);
+		saved[0] = 9;
+		assertArrayEquals(new byte[]{1, 2, 3}, contents);
+	}
+
+	@Test
+	public void testEmptyArchiveAndEmptyFile()
+	{
+		ArchiveFiles files = new ArchiveFiles();
+		assertArrayEquals(new byte[]{1}, files.saveContents());
+		addFile(files, 10, new byte[0]);
+		assertArrayEquals(new byte[0], files.saveContents());
+	}
+
+	@Test
+	public void testSavePreservesInsertionOrderAndNegativeDeltas() throws IOException
+	{
+		byte[][][] chunks = {{{1, 2, 3}, {}, {4}, {5, 6}}};
+		ArchiveFiles files = new ArchiveFiles();
+		addFile(files, 20, chunks[0][0]);
+		addFile(files, 5, chunks[0][1]);
+		addFile(files, 12, chunks[0][2]);
+		addFile(files, 100, chunks[0][3]);
+		assertArrayEquals(encodeChunks(chunks), files.saveContents());
+		files.loadContents(files.saveContents());
+		assertArrayEquals(chunks[0][0], files.findFile(20).getContents());
+		assertArrayEquals(chunks[0][1], files.findFile(5).getContents());
+		assertArrayEquals(chunks[0][2], files.findFile(12).getContents());
+		assertArrayEquals(chunks[0][3], files.findFile(100).getContents());
+	}
+
+	@Test
+	public void testMultipleChunks() throws IOException
+	{
+		byte[][][] chunks =
+		{
+			{{1, 2}, {9}, {}},
+			{{3}, {8, 7, 6}, {5}}
+		};
+		ArchiveFiles files = new ArchiveFiles();
+		addFile(files, 20, new byte[0]);
+		addFile(files, 5, new byte[0]);
+		addFile(files, 100, new byte[0]);
+		files.loadContents(encodeChunks(chunks));
+		assertArrayEquals(new byte[]{1, 2, 3}, files.findFile(20).getContents());
+		assertArrayEquals(new byte[]{9, 8, 7, 6}, files.findFile(5).getContents());
+		assertArrayEquals(new byte[]{5}, files.findFile(100).getContents());
+	}
+
+	@Test
+	public void testMaximumChunkCount() throws IOException
+	{
+		int fileCount = 20;
+		byte[][][] chunks = new byte[255][fileCount][];
+		ByteArrayOutputStream[] expected = new ByteArrayOutputStream[fileCount];
+		ArchiveFiles files = new ArchiveFiles();
+		for (int file = 0; file < fileCount; ++file)
+		{
+			expected[file] = new ByteArrayOutputStream();
+			addFile(files, file * 3, new byte[0]);
+		}
+
+		Random random = new Random(0);
+		for (byte[][] chunk : chunks)
+		{
+			for (int file = 0; file < fileCount; ++file)
+			{
+				byte[] contents = new byte[random.nextInt(50)];
+				random.nextBytes(contents);
+				chunk[file] = contents;
+				expected[file].write(contents);
+			}
+		}
+
+		byte[] encoded = encodeChunks(chunks);
+		byte[] original = encoded.clone();
+		files.loadContents(encoded);
+		assertArrayEquals(original, encoded);
+		for (int file = 0; file < fileCount; ++file)
+		{
+			assertArrayEquals(expected[file].toByteArray(), files.findFile(file * 3).getContents());
+		}
+	}
+
+	private static void addFile(ArchiveFiles files, int id, byte[] contents)
+	{
+		FSFile file = new FSFile(id);
+		file.setContents(contents);
+		files.addFile(file);
+	}
+
+	private static byte[] encodeChunks(byte[][][] chunks) throws IOException
+	{
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		DataOutputStream output = new DataOutputStream(bytes);
+		for (byte[][] chunk : chunks)
+		{
+			for (byte[] file : chunk)
+			{
+				output.write(file);
+			}
+		}
+		for (byte[][] chunk : chunks)
+		{
+			int previousSize = 0;
+			for (byte[] file : chunk)
+			{
+				output.writeInt(file.length - previousSize);
+				previousSize = file.length;
+			}
+		}
+		output.writeByte(chunks.length);
+		return bytes.toByteArray();
+	}
+}

--- a/cache/src/test/java/net/runelite/cache/fs/IndexTest.java
+++ b/cache/src/test/java/net/runelite/cache/fs/IndexTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.cache.fs;
+
+import java.util.Random;
+import net.runelite.cache.util.Djb2;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class IndexTest
+{
+	@Test
+	public void testLookupAfterAddingArchive()
+	{
+		Index index = new Index(0);
+		assertNull(index.findArchiveByName("map"));
+		assertNull(index.findArchiveByName(""));
+
+		Archive archive = index.addArchive(7);
+		assertSame(archive, index.findArchiveByName(""));
+		archive.setNameHash(Djb2.hash("map"));
+		assertSame(archive, index.findArchiveByName("map"));
+		assertNull(index.findArchiveByName(""));
+		assertNull(index.findArchiveByName("missing"));
+	}
+
+	@Test
+	public void testHashCollisionUsesLowestArchiveId()
+	{
+		assertEquals(Djb2.hash("Aa"), Djb2.hash("BB"));
+		Index index = new Index(0);
+		Archive higher = index.addArchive(20);
+		higher.setNameHash(Djb2.hash("Aa"));
+		assertSame(higher, index.findArchiveByName("BB"));
+
+		Archive lower = index.addArchive(10);
+		lower.setNameHash(Djb2.hash("BB"));
+		assertSame(lower, index.findArchiveByName("Aa"));
+		assertSame(lower, index.findArchiveByName("BB"));
+
+		assertTrue(index.removeArchive(lower));
+		assertSame(higher, index.findArchiveByName("Aa"));
+		assertTrue(index.removeArchive(higher));
+		assertNull(index.findArchiveByName("BB"));
+	}
+
+	@Test
+	public void testRenameUpdatesBothHashes()
+	{
+		Index index = new Index(0);
+		Archive lower = index.addArchive(10);
+		lower.setNameHash(Djb2.hash("original"));
+		Archive higher = index.addArchive(20);
+		higher.setNameHash(Djb2.hash("original"));
+		assertSame(lower, index.findArchiveByName("original"));
+
+		lower.setNameHash(Djb2.hash("renamed"));
+		assertSame(lower, index.findArchiveByName("renamed"));
+		assertSame(higher, index.findArchiveByName("original"));
+
+		higher.setNameHash(Djb2.hash("renamed"));
+		assertSame(lower, index.findArchiveByName("renamed"));
+		assertNull(index.findArchiveByName("original"));
+	}
+
+	@Test
+	public void testRemovalByEqualArchive()
+	{
+		Index index = new Index(0);
+		Archive archive = index.addArchive(10);
+		archive.setNameHash(Djb2.hash("map"));
+		assertSame(archive, index.findArchiveByName("map"));
+
+		Archive equivalent = new Archive(index, 10);
+		equivalent.setNameHash(archive.getNameHash());
+		assertSame(archive, index.findArchiveByName("map"));
+		assertTrue(index.removeArchive(equivalent));
+		assertNull(index.findArchiveByName("map"));
+		assertFalse(index.removeArchive(equivalent));
+	}
+
+	@Test
+	public void testLookupsMatchLinearScanAfterMutations()
+	{
+		Index index = new Index(0);
+		Random random = new Random(0);
+		String[] names = {"", "Aa", "BB", "map", "location", "missing"};
+		for (int iteration = 0; iteration < 1000; ++iteration)
+		{
+			int id = random.nextInt(100);
+			Archive archive = index.getArchive(id);
+			if (archive == null)
+			{
+				archive = index.addArchive(id);
+			}
+			else if (random.nextBoolean())
+			{
+				index.removeArchive(archive);
+			}
+			archive.setNameHash(Djb2.hash(names[random.nextInt(names.length - 1)]));
+
+			for (String name : names)
+			{
+				Archive expected = null;
+				for (Archive candidate : index.getArchives())
+				{
+					if (candidate.getNameHash() == Djb2.hash(name))
+					{
+						expected = candidate;
+						break;
+					}
+				}
+				assertSame(expected, index.findArchiveByName(name));
+			}
+		}
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/geometry/RectangleUnion.java
+++ b/runelite-api/src/main/java/net/runelite/api/geometry/RectangleUnion.java
@@ -27,6 +27,8 @@ package net.runelite.api.geometry;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -330,9 +332,17 @@ public class RectangleUnion
 	private static class Segments
 	{
 		Segment first;
+		private TreeMap<Integer, Segment> byY;
+		private int size;
 
 		Segment findLE(int y)
 		{
+			if (byY != null)
+			{
+				return findIndexedLE(y);
+			}
+
+			// Avoid allocating an index for small clickboxes.
 			Segment s = first;
 			if (s == null || s.y > y)
 			{
@@ -353,6 +363,29 @@ public class RectangleUnion
 
 				s = n;
 			}
+		}
+
+		private Segment findIndexedLE(int y)
+		{
+			if (y <= first.y)
+			{
+				return y == first.y ? first : null;
+			}
+			// Removal edges and repeated y coordinates already have a segment.
+			Segment exact = byY.get(y);
+			if (exact != null)
+			{
+				return exact;
+			}
+			Map.Entry<Integer, Segment> entry = byY.floorEntry(y);
+			Segment s = entry.getValue();
+			// Zero-height rectangles can introduce duplicate edges. An exact
+			// match uses the first; an insertion after them uses the last.
+			while (s.next != null && s.next.y == s.y)
+			{
+				s = s.next;
+			}
+			return s;
 		}
 
 		Segment insertAfter(Segment before, int y)
@@ -379,6 +412,21 @@ public class RectangleUnion
 				}
 				first = n;
 			}
+			if (byY != null)
+			{
+				byY.putIfAbsent(y, n);
+			}
+			else if (++size > 256)
+			{
+				// Bound predecessor searches as the sweep accumulates y edges. Keep
+				// the linked list for traversing the segments covered by an edge.
+				byY = new TreeMap<>();
+				for (Segment s = first; s != null; s = s.next)
+				{
+					byY.putIfAbsent(s.y, s);
+				}
+			}
+
 			return n;
 		}
 

--- a/runelite-api/src/main/java/net/runelite/api/geometry/SimplePolygon.java
+++ b/runelite-api/src/main/java/net/runelite/api/geometry/SimplePolygon.java
@@ -65,7 +65,7 @@ public class SimplePolygon implements Shape
 		left--;
 		if (left < 0)
 		{
-			expandLeft(GROW);
+			expandLeft(Math.max(GROW, x.length / 2));
 		}
 		x[left] = xCoord;
 		y[left] = yCoord;
@@ -93,7 +93,7 @@ public class SimplePolygon implements Shape
 		right++;
 		if (right >= x.length)
 		{
-			expandRight(GROW);
+			expandRight(Math.max(GROW, x.length / 2));
 		}
 		x[right] = xCoord;
 		y[right] = yCoord;
@@ -152,7 +152,18 @@ public class SimplePolygon implements Shape
 		{
 			return;
 		}
-		other.expandRight(size);
+		// Distinct polygons may be views over the same coordinate arrays. Preserve
+		// the source when appending into an overlapping part of those arrays.
+		boolean shared = other != this && (x == other.x || x == other.y || y == other.x || y == other.y);
+		int required = other.right + 1 + size - other.x.length;
+		if (required > 0)
+		{
+			other.expandRight(Math.max(required, Math.max(GROW, other.x.length / 2)));
+		}
+		else if (shared)
+		{
+			other.expandRight(0);
+		}
 		copyTo(other.x, other.y, other.right + 1);
 		other.right += size;
 	}

--- a/runelite-api/src/test/java/net/runelite/api/geometry/RectangleUnionTest.java
+++ b/runelite-api/src/test/java/net/runelite/api/geometry/RectangleUnionTest.java
@@ -27,15 +27,19 @@ package net.runelite.api.geometry;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Shape;
+import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import javax.imageio.ImageIO;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
+import org.junit.Test;
 
 @Slf4j
 public class RectangleUnionTest
@@ -43,6 +47,92 @@ public class RectangleUnionTest
 	private static final int ITERATIONS = 100;
 	private static final int WIDTH = 1000;
 	private static final int MAX_RECTS = 50;
+
+	@Test
+	public void empty()
+	{
+		Assert.assertNull(RectangleUnion.union(new ArrayList<>()));
+	}
+
+	@Test
+	public void sharedEdgesAndNestedRectangles()
+	{
+		assertUnion(Arrays.asList(
+			new RectangleUnion.Rectangle(-20, -20, 0, 0),
+			new RectangleUnion.Rectangle(0, -20, 20, 0),
+			new RectangleUnion.Rectangle(-20, 0, 20, 20),
+			new RectangleUnion.Rectangle(-10, -10, 10, 10),
+			new RectangleUnion.Rectangle(-20, -20, 0, 0)));
+	}
+
+	@Test
+	public void disjointRectangles()
+	{
+		List<RectangleUnion.Rectangle> rects = new ArrayList<>();
+		for (int i = 0; i < 256; i++)
+		{
+			rects.add(new RectangleUnion.Rectangle(i * 3, i * 4 - 512, i * 3 + 2, i * 4 - 510));
+		}
+		Collections.shuffle(rects, new Random(123));
+		assertUnion(rects);
+	}
+
+	@Test
+	public void hole()
+	{
+		assertUnion(Arrays.asList(
+			new RectangleUnion.Rectangle(0, 0, 30, 10),
+			new RectangleUnion.Rectangle(0, 20, 30, 30),
+			new RectangleUnion.Rectangle(0, 10, 10, 20),
+			new RectangleUnion.Rectangle(20, 10, 30, 20)));
+	}
+
+	@Test
+	public void zeroWidthAndHeight()
+	{
+		assertUnion(Arrays.asList(new RectangleUnion.Rectangle(0, 0, 1, 0)));
+		assertUnion(Arrays.asList(new RectangleUnion.Rectangle(0, 0, 0, 1)));
+		List<RectangleUnion.Rectangle> rects = new ArrayList<>();
+		for (int i = 0; i < 200; i++)
+		{
+			rects.add(new RectangleUnion.Rectangle(i * 2, i * 4, i * 2 + 1, i * 4 + 2));
+		}
+		rects.add(new RectangleUnion.Rectangle(500, 123, 501, 123));
+		rects.add(new RectangleUnion.Rectangle(500, 122, 500, 125));
+		rects.add(new RectangleUnion.Rectangle(500, 120, 505, 126));
+		assertUnion(rects);
+	}
+
+	@Test
+	public void randomizedUnions()
+	{
+		Random random = new Random(0x5eed);
+		for (int iteration = 0; iteration < 200; iteration++)
+		{
+			List<RectangleUnion.Rectangle> rects = new ArrayList<>();
+			int count = 1 + random.nextInt(50);
+			for (int i = 0; i < count; i++)
+			{
+				int x = random.nextInt(100) - 50;
+				int y = random.nextInt(100) - 50;
+				rects.add(new RectangleUnion.Rectangle(x, y, x + 1 + random.nextInt(30), y + 1 + random.nextInt(30)));
+			}
+			assertUnion(rects);
+		}
+	}
+
+	private static void assertUnion(List<RectangleUnion.Rectangle> rects)
+	{
+		Area expected = new Area();
+		for (RectangleUnion.Rectangle rect : rects)
+		{
+			expected.add(new Area(new java.awt.Rectangle(rect.getX1(), rect.getY1(),
+				rect.getX2() - rect.getX1(), rect.getY2() - rect.getY1())));
+		}
+		Area actual = new Area(RectangleUnion.union(new ArrayList<>(rects)));
+		expected.exclusiveOr(actual);
+		Assert.assertTrue("Rectangle union differs from java.awt.geom.Area", expected.isEmpty());
+	}
 
 	// @Test
 	public void test() throws IOException

--- a/runelite-api/src/test/java/net/runelite/api/geometry/SimplePolygonTest.java
+++ b/runelite-api/src/test/java/net/runelite/api/geometry/SimplePolygonTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2019 Abex
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.geometry;
+
+import java.awt.Rectangle;
+import java.awt.geom.Area;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SimplePolygonTest
+{
+	@Test
+	public void growsInBothDirections()
+	{
+		SimplePolygon polygon = new SimplePolygon();
+		for (int i = 0; i < 2000; i++)
+		{
+			polygon.pushRight(i, i * 2);
+			polygon.pushLeft(-i - 1, (-i - 1) * 2);
+		}
+		Assert.assertEquals(4000, polygon.size());
+		for (int i = 0; i < polygon.size(); i++)
+		{
+			Assert.assertEquals(i - 2000, polygon.getX(i));
+			Assert.assertEquals((i - 2000) * 2, polygon.getY(i));
+		}
+	}
+
+	@Test
+	public void growsFromEmptyArrays()
+	{
+		SimplePolygon polygon = new SimplePolygon(new int[0], new int[0], 0);
+		polygon.pushRight(1, 2);
+		polygon.pushLeft(3, 4);
+		Assert.assertEquals(2, polygon.size());
+		Assert.assertEquals(3, polygon.getX(0));
+		Assert.assertEquals(4, polygon.getY(0));
+		Assert.assertEquals(1, polygon.getX(1));
+		Assert.assertEquals(2, polygon.getY(1));
+	}
+
+	@Test
+	public void appendsOnlyActiveVertices()
+	{
+		SimplePolygon source = new SimplePolygon(new int[]{0, 1, 2, 3}, new int[]{0, 2, 4, 6}, 4);
+		source.popLeft();
+		source.popRight();
+		SimplePolygon destination = new SimplePolygon();
+		destination.pushLeft(-1, -2);
+		for (int i = 0; i < 1000; i++)
+		{
+			source.appendTo(destination);
+		}
+		Assert.assertEquals(2001, destination.size());
+		Assert.assertEquals(-1, destination.getX(0));
+		Assert.assertEquals(-2, destination.getY(0));
+		for (int i = 1; i < destination.size(); i++)
+		{
+			Assert.assertEquals(2 - i % 2, destination.getX(i));
+			Assert.assertEquals((2 - i % 2) * 2, destination.getY(i));
+		}
+		Assert.assertEquals(2, source.size());
+		Assert.assertEquals(1, source.getX(0));
+		Assert.assertEquals(2, source.getX(1));
+	}
+
+	@Test
+	public void appendsToSelf()
+	{
+		SimplePolygon polygon = new SimplePolygon(new int[]{1, 2, 3}, new int[]{2, 4, 6}, 3);
+		for (int iteration = 0; iteration < 5; iteration++)
+		{
+			polygon.appendTo(polygon);
+		}
+		Assert.assertEquals(96, polygon.size());
+		for (int i = 0; i < polygon.size(); i++)
+		{
+			Assert.assertEquals(i % 3 + 1, polygon.getX(i));
+			Assert.assertEquals((i % 3 + 1) * 2, polygon.getY(i));
+		}
+	}
+
+	@Test
+	public void appendingSharedArraysPreservesSource()
+	{
+		int[] x = new int[]{0, 1, 2, 3, 4, 5, 6, 7};
+		int[] y = new int[]{0, 2, 4, 6, 8, 10, 12, 14};
+		SimplePolygon source = new SimplePolygon(x, y, 2, 3);
+		SimplePolygon destination = new SimplePolygon(x, y, 0, 2);
+		source.appendTo(destination);
+		Assert.assertEquals(2, source.getX(0));
+		Assert.assertEquals(3, source.getX(1));
+		Assert.assertEquals(4, source.getY(0));
+		Assert.assertEquals(6, source.getY(1));
+		Assert.assertEquals(5, destination.size());
+		Assert.assertEquals(2, destination.getX(3));
+		Assert.assertEquals(3, destination.getX(4));
+	}
+
+	@Test
+	public void clippingAfterGrowth()
+	{
+		SimplePolygon polygon = new SimplePolygon();
+		for (int i = 0; i < 100; i++)
+		{
+			polygon.pushRight(0, i);
+		}
+		for (int i = 0; i < 100; i++)
+		{
+			polygon.pushRight(i, 100);
+		}
+		for (int i = 100; i > 0; i--)
+		{
+			polygon.pushRight(100, i);
+		}
+		for (int i = 100; i > 0; i--)
+		{
+			polygon.pushRight(i, 0);
+		}
+		SimplePolygon clip = new SimplePolygon(new int[]{20, 20, 80, 80}, new int[]{20, 80, 80, 20}, 4);
+		polygon.intersectWithConvex(clip);
+		Area difference = new Area(new Rectangle(20, 20, 60, 60));
+		difference.exclusiveOr(new Area(polygon));
+		Assert.assertTrue(difference.isEmpty());
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/AlphaFaceSorter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/AlphaFaceSorter.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.gpu;
+
+import java.nio.IntBuffer;
+import java.util.Arrays;
+
+/**
+ * The depth order of static faces depends only on camera direction. Share this
+ * cache with temporary copies of a model rendered from a neighboring zone.
+ */
+final class AlphaFaceSorter
+{
+	final int radius;
+	private final int[] packedFaces;
+	private char[] sortedFaces;
+	private boolean directionInitialized, cacheValid;
+	private int lastYawSin, lastYawCos, lastPitchSin, lastPitchCos;
+
+	AlphaFaceSorter(int radius, int[] packedFaces)
+	{
+		this.radius = radius;
+		this.packedFaces = packedFaces;
+	}
+
+	int faceCount()
+	{
+		return packedFaces.length;
+	}
+
+	void writeIndices(int yawSin, int yawCos, int pitchSin, int pitchCos, char[] head, char[] tail, char[] next, IntBuffer output, int start)
+	{
+		boolean sameDirection = directionInitialized
+			&& yawSin == lastYawSin && yawCos == lastYawCos
+			&& pitchSin == lastPitchSin && pitchCos == lastPitchCos;
+		if (sameDirection && cacheValid)
+		{
+			for (char face : sortedFaces)
+			{
+				putFace(output, face, start);
+			}
+			return;
+		}
+
+		int diameter = 1 + radius * 2;
+		Arrays.fill(head, 0, diameter, (char) -1);
+
+		for (char i = 0; i < packedFaces.length; ++i)
+		{
+			int pack = packedFaces[i];
+			int x = pack >> 21;
+			int y = (pack << 11) >> 22;
+			int z = (pack << 21) >> 21;
+
+			int t = z * yawCos - x * yawSin >> 16;
+			int depth = (y * pitchSin + t * pitchCos >> 16) + radius;
+			assert depth >= 0 && depth < diameter : depth;
+
+			if (head[depth] == (char) -1)
+			{
+				head[depth] = i;
+			}
+			else
+			{
+				next[tail[depth]] = i;
+			}
+			tail[depth] = i;
+			next[i] = (char) -1;
+		}
+
+		// Populate the cache only after the camera direction repeats. While the
+		// camera is rotating, emit directly without the additional cache writes.
+		if (sameDirection)
+		{
+			if (sortedFaces == null)
+			{
+				sortedFaces = new char[packedFaces.length];
+			}
+			int offset = 0;
+			for (int depth = diameter - 1; depth >= 0; --depth)
+			{
+				for (char face = head[depth]; face != (char) -1; face = next[face])
+				{
+					sortedFaces[offset++] = face;
+					putFace(output, face, start);
+				}
+			}
+		}
+		else
+		{
+			for (int depth = diameter - 1; depth >= 0; --depth)
+			{
+				for (char face = head[depth]; face != (char) -1; face = next[face])
+				{
+					putFace(output, face, start);
+				}
+			}
+		}
+
+		cacheValid = sameDirection;
+		directionInitialized = true;
+		lastYawSin = yawSin;
+		lastYawCos = yawCos;
+		lastPitchSin = pitchSin;
+		lastPitchCos = pitchCos;
+	}
+
+	private static void putFace(IntBuffer output, int face, int start)
+	{
+		int faceIdx = face * 3 + start;
+		output.put(faceIdx++);
+		output.put(faceIdx++);
+		output.put(faceIdx);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/Zone.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/Zone.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.gpu;
 import java.nio.IntBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -310,15 +309,14 @@ class Zone
 		byte flags;
 
 		// only set for static geometry as they require sorting
-		int radius;
-		int[] packedFaces;
+		AlphaFaceSorter faceSorter;
 
 		static final int SKIP = 1; // temporary model is in a closer zone
 		static final int TEMP = 2; // temporary model added to a closer zone
 
 		boolean isTemp()
 		{
-			return packedFaces == null;
+			return faceSorter == null;
 		}
 	}
 
@@ -396,7 +394,7 @@ class Zone
 			shift++;
 		}
 
-		int[] packedFaces = m.packedFaces = new int[(endpos - startpos) / ((3 * VERT_SIZE) >> 2)];
+		int[] packedFaces = new int[(endpos - startpos) / ((3 * VERT_SIZE) >> 2)];
 		int radius = 0;
 		char bufferIdx = 0;
 		for (int f = 0; f < faceCount; ++f)
@@ -420,7 +418,7 @@ class Zone
 
 		assert radius >= 0;
 
-		m.radius = 2 + (int) Math.sqrt(radius);
+		m.faceSorter = new AlphaFaceSorter(2 + (int) Math.sqrt(radius), packedFaces);
 
 		assert packedFaces.length > 0;
 		assert bufferIdx == packedFaces.length;
@@ -462,7 +460,7 @@ class Zone
 			if (m.isTemp() || (m.flags & AlphaModel.TEMP) != 0)
 			{
 				alphaModels.remove(i);
-				m.packedFaces = null;
+				m.faceSorter = null;
 				modelCache.add(m);
 			}
 			m.flags &= ~AlphaModel.SKIP;
@@ -590,50 +588,18 @@ class Zone
 
 			lastDrawMode = STATIC;
 
-			final int radius = m.radius;
-			int diameter = 1 + radius * 2;
-			final int[] packedFaces = m.packedFaces;
-			if (diameter >= MAX_DIAMETER)
+			AlphaFaceSorter faceSorter = m.faceSorter;
+			if (1 + faceSorter.radius * 2 >= MAX_DIAMETER)
 			{
 				continue;
 			}
 
-			Arrays.fill(mu.zsortHead, 0, diameter, (char) -1);
-			Arrays.fill(mu.zsortTail, 0, diameter, (char) -1);
-
-			for (char i = 0; i < packedFaces.length; ++i)
+			int faceCount = faceSorter.faceCount();
+			if (faceCount * 3 > alphaElements.remaining())
 			{
-				int pack = packedFaces[i];
-
-				int x = pack >> 21;
-				int y = (pack << 11) >> 22;
-				int z = (pack << 21) >> 21;
-
-				int t = z * yawcos - x * yawsin >> 16;
-				int fz = y * pitchsin + t * pitchcos >> 16;
-				fz += radius;
-
-				assert fz >= 0 && fz < diameter : fz;
-
-				if (mu.zsortTail[fz] == (char) -1)
+				if (faceCount * 3 > alphaElements.capacity())
 				{
-					mu.zsortHead[fz] = mu.zsortTail[fz] = i;
-					mu.zsortNext[i] = (char) -1;
-				}
-				else
-				{
-					char lastFace = mu.zsortTail[fz];
-					mu.zsortNext[lastFace] = i;
-					mu.zsortNext[i] = (char) -1;
-					mu.zsortTail[fz] = i;
-				}
-			}
-
-			if (packedFaces.length * 3 > alphaElements.remaining())
-			{
-				if (packedFaces.length * 3 > alphaElements.capacity())
-				{
-					log.debug("Alpha model too large: {}", packedFaces.length);
+					log.debug("Alpha model too large: {}", faceCount);
 					continue;
 				}
 
@@ -641,17 +607,7 @@ class Zone
 			}
 
 			final int start = m.startpos / (VERT_SIZE >> 2); // ints to verts
-			for (int i = diameter - 1; i >= 0; --i)
-			{
-				for (char face = mu.zsortHead[i]; face != (char) -1; face = mu.zsortNext[face])
-				{
-					int faceIdx = face * 3;
-					faceIdx += start;
-					alphaElements.put(faceIdx++);
-					alphaElements.put(faceIdx++);
-					alphaElements.put(faceIdx++);
-				}
-			}
+			faceSorter.writeIndices(yawsin, yawcos, pitchsin, pitchcos, mu.zsortHead, mu.zsortTail, mu.zsortNext, alphaElements, start);
 		}
 
 		flush();
@@ -764,8 +720,7 @@ class Zone
 				m2.zofx = (byte) (closestZoneX - zx);
 				m2.zofz = (byte) (closestZoneZ - zz);
 
-				m2.packedFaces = m.packedFaces;
-				m2.radius = m.radius;
+				m2.faceSorter = m.faceSorter;
 
 				m2.flags = AlphaModel.TEMP;
 				m.flags |= AlphaModel.SKIP;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -351,8 +351,14 @@ public class GroundItemsPlugin extends Plugin
 			return;
 		}
 
-		final MenuEntry[] menuEntries = client.getMenuEntries();
+		client.setMenuEntries(collapseEntries(client.getMenuEntries()));
+	}
+
+	static MenuEntry[] collapseEntries(MenuEntry[] menuEntries)
+	{
 		final List<MenuEntryWithCount> newEntries = new ArrayList<>(menuEntries.length);
+		// Small menus are cheaper to scan than to hash and allocate a map for.
+		final Map<MenuEntry, MenuEntryWithCount> groundEntries = menuEntries.length > 32 ? new HashMap<>() : null;
 
 		outer:
 		for (int i = menuEntries.length - 1; i >= 0; i--)
@@ -360,27 +366,46 @@ public class GroundItemsPlugin extends Plugin
 			MenuEntry menuEntry = menuEntries[i];
 
 			MenuAction menuType = menuEntry.getType();
-			if (menuType == MenuAction.GROUND_ITEM_FIRST_OPTION || menuType == MenuAction.GROUND_ITEM_SECOND_OPTION
+			boolean groundItem = menuType == MenuAction.GROUND_ITEM_FIRST_OPTION || menuType == MenuAction.GROUND_ITEM_SECOND_OPTION
 				|| menuType == MenuAction.GROUND_ITEM_THIRD_OPTION || menuType == MenuAction.GROUND_ITEM_FOURTH_OPTION
-				|| menuType == MenuAction.GROUND_ITEM_FIFTH_OPTION || menuType == MenuAction.EXAMINE_ITEM_GROUND)
+				|| menuType == MenuAction.GROUND_ITEM_FIFTH_OPTION || menuType == MenuAction.EXAMINE_ITEM_GROUND;
+			if (groundItem)
 			{
-				for (MenuEntryWithCount entryWCount : newEntries)
+				if (groundEntries != null)
 				{
-					if (entryWCount.getEntry().equals(menuEntry))
+					MenuEntryWithCount entryWithCount = groundEntries.get(menuEntry);
+					if (entryWithCount != null)
 					{
-						entryWCount.increment();
-						continue outer;
+						entryWithCount.increment();
+						continue;
+					}
+				}
+				else
+				{
+					for (MenuEntryWithCount entryWithCount : newEntries)
+					{
+						if (entryWithCount.getEntry().equals(menuEntry))
+						{
+							entryWithCount.increment();
+							continue outer;
+						}
 					}
 				}
 			}
 
-			newEntries.add(new MenuEntryWithCount(menuEntry));
+			MenuEntryWithCount entryWithCount = new MenuEntryWithCount(menuEntry);
+			newEntries.add(entryWithCount);
+			if (groundEntries != null && groundItem)
+			{
+				groundEntries.put(menuEntry, entryWithCount);
+			}
 		}
 
-		Collections.reverse(newEntries);
-
-		client.setMenuEntries(newEntries.stream().map(e ->
+		// Finish all lookups before changing targets: MenuEntry equality includes the target.
+		final MenuEntry[] collapsedEntries = new MenuEntry[newEntries.size()];
+		for (int i = 0; i < collapsedEntries.length; i++)
 		{
+			MenuEntryWithCount e = newEntries.get(collapsedEntries.length - 1 - i);
 			final MenuEntry entry = e.getEntry();
 			final int count = e.getCount();
 			if (count > 1)
@@ -388,8 +413,9 @@ public class GroundItemsPlugin extends Plugin
 				entry.setTarget(entry.getTarget() + " x " + count);
 			}
 
-			return entry;
-		}).toArray(MenuEntry[]::new));
+			collapsedEntries[i] = entry;
+		}
+		return collapsedEntries;
 	}
 
 	private GroundItem buildGroundItem(final ItemLayer layer, final TileItem item)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/ItemList.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/ItemList.java
@@ -24,46 +24,69 @@
  */
 package net.runelite.client.plugins.grounditems;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
 import lombok.Value;
 import net.runelite.client.util.WildcardMatcher;
 
-@Value
 class ItemList
 {
 	static final int NONE = 0;
 	static final int WILDCARD = 1;
 	static final int EXACT = 2;
 
-	List<ItemThreshold> items;
+	// Use the same case folding as String.equalsIgnoreCase, including non-ASCII names.
+	private final Map<String, List<ItemThreshold>> exactItems = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+	private final List<WildcardItem> wildcardItems = new ArrayList<>();
+
+	@Value
+	private static class WildcardItem
+	{
+		ItemThreshold threshold;
+		Pattern pattern;
+	}
 
 	ItemList(List<String> items)
 	{
-		this.items = items.stream()
-			.map(ItemThreshold::fromName)
-			.filter(Objects::nonNull)
-			.collect(Collectors.toList());
+		for (String name : items)
+		{
+			ItemThreshold threshold = ItemThreshold.fromName(name);
+			if (threshold == null)
+			{
+				continue;
+			}
+			if (threshold.isWildcard())
+			{
+				wildcardItems.add(new WildcardItem(threshold, WildcardMatcher.compile(threshold.getName())));
+			}
+			else
+			{
+				exactItems.computeIfAbsent(threshold.getName(), k -> new ArrayList<>()).add(threshold);
+			}
+		}
 	}
 
 	int matches(GroundItem item)
 	{
-		for (ItemThreshold it : items)
+		List<ItemThreshold> exact = exactItems.get(item.getName());
+		if (exact != null)
 		{
-			if (!it.isWildcard()
-				&& it.getName().equalsIgnoreCase(item.getName())
-				&& it.quantityHolds(item.getQuantity()))
+			for (ItemThreshold it : exact)
 			{
-				return EXACT;
+				if (it.quantityHolds(item.getQuantity()))
+				{
+					return EXACT;
+				}
 			}
 		}
 
-		for (ItemThreshold it : items)
+		for (WildcardItem it : wildcardItems)
 		{
-			if (it.isWildcard()
-				&& WildcardMatcher.matches(it.getName(), item.getName())
-				&& it.quantityHolds(item.getQuantity()))
+			if (it.threshold.quantityHolds(item.getQuantity())
+				&& it.pattern.matcher(item.getName()).matches())
 			{
 				return WILDCARD;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -81,7 +81,32 @@ public class Text
 	 */
 	public static String removeTags(String str)
 	{
-		return TAG_REGEXP.matcher(str).replaceAll("");
+		int start = str.indexOf('<');
+		if (start == -1)
+		{
+			return str;
+		}
+		int end = str.indexOf('>', start + 1);
+		if (end == -1)
+		{
+			return str;
+		}
+
+		StringBuilder result = new StringBuilder(str.length());
+		int offset = 0;
+		do
+		{
+			result.append(str, offset, start);
+			offset = end + 1;
+			start = str.indexOf('<', offset);
+			if (start == -1)
+			{
+				break;
+			}
+			end = str.indexOf('>', start + 1);
+		}
+		while (end != -1);
+		return result.append(str, offset, str.length()).toString();
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/util/WildcardMatcher.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/WildcardMatcher.java
@@ -33,6 +33,11 @@ public class WildcardMatcher
 
 	public static boolean matches(String pattern, String text)
 	{
+		return compile(pattern).matcher(text).matches();
+	}
+
+	public static Pattern compile(String pattern)
+	{
 		final Matcher matcher = WILDCARD_PATTERN.matcher(pattern);
 		final StringBuilder buffer = new StringBuilder();
 
@@ -50,8 +55,6 @@ public class WildcardMatcher
 		}
 
 		matcher.appendTail(buffer);
-		final String replaced = buffer.toString();
-
-		return text.matches(replaced);
+		return Pattern.compile(buffer.toString());
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/gpu/AlphaFaceSorterTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/gpu/AlphaFaceSorterTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2025, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.gpu;
+
+import java.nio.IntBuffer;
+import java.util.Arrays;
+import java.util.Random;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class AlphaFaceSorterTest
+{
+	private final char[] head = new char[6000];
+	private final char[] tail = new char[6000];
+	private final char[] next = new char[8192];
+
+	@Test
+	public void matchesStableDepthSort()
+	{
+		Random random = new Random(0xA1FA);
+		for (int count : new int[]{0, 1, 2, 32, 256, 8192})
+		{
+			int[][] positions = new int[count][3];
+			for (int[] position : positions)
+			{
+				position[0] = random.nextInt(2048) - 1024;
+				position[1] = random.nextInt(1024) - 512;
+				position[2] = random.nextInt(2048) - 1024;
+			}
+			AlphaFaceSorter sorter = sorter(1600, positions);
+			assertEquals(count, sorter.faceCount());
+
+			for (int i = 0; i < 64; ++i)
+			{
+				int[] direction = direction(random.nextInt(16384), random.nextInt(16384));
+				assertArrayEquals(expected(positions, direction), sort(sorter, direction));
+			}
+		}
+	}
+
+	@Test
+	public void retainsInputOrderAtEqualDepthAndSignedPackingBoundaries()
+	{
+		int[][] positions = {
+			{-1024, -512, -1024}, {1023, 511, 1023},
+			{1023, -512, -1024}, {-1024, 511, 1023},
+			{0, 0, 0}, {0, 0, 0}
+		};
+		AlphaFaceSorter sorter = sorter(1600, positions);
+		for (int yaw : new int[]{0, 4096, 8192, 12288, 16383})
+		{
+			for (int pitch : new int[]{0, 4096, 8192, 12288, 16383})
+			{
+				int[] direction = direction(yaw, pitch);
+				assertArrayEquals(expected(positions, direction), sort(sorter, direction));
+			}
+		}
+	}
+
+	@Test
+	public void reusesOrderWithoutDependingOnSharedScratchBuffers()
+	{
+		int[][] positions = {{0, 0, -20}, {0, 0, 20}, {10, 5, 0}};
+		AlphaFaceSorter sorter = sorter(24, positions);
+		int[] direction = direction(0, 0);
+		sort(sorter, direction);
+		char[] order = sort(sorter, direction);
+
+		// Another model uses the same render thread's scratch buffers.
+		AlphaFaceSorter other = sorter(2, new int[][]{{0, 0, 0}});
+		sort(other, direction(8192, 2048));
+		char[] savedHead = head.clone();
+		char[] savedTail = tail.clone();
+		char[] savedNext = next.clone();
+
+		assertArrayEquals(order, sort(sorter, direction));
+		assertArrayEquals(expected(positions, direction), order);
+		assertArrayEquals(savedHead, head);
+		assertArrayEquals(savedTail, tail);
+		assertArrayEquals(savedNext, next);
+	}
+
+	@Test
+	public void invalidatesOnEitherCameraAngleAndWhenCameraReturns()
+	{
+		int[][] positions = {{-10, -10, -10}, {10, 10, 10}, {10, -10, 10}, {-10, 10, -10}};
+		AlphaFaceSorter sorter = sorter(20, positions);
+		for (int[] direction : new int[][]{
+			direction(0, 0), direction(8192, 0), direction(8192, 4096),
+			direction(8192, 12288), direction(0, 0)})
+		{
+			for (int i = 0; i < 3; ++i)
+			{
+				// Miss, cache population, and cache hit, with changing buffer offsets.
+				assertArrayEquals(expected(positions, direction), sort(sorter, direction, 123 + i * 30));
+			}
+		}
+	}
+
+	@Test
+	public void includesBothDepthRangeBoundaries()
+	{
+		int[][] positions = {{0, 0, -2}, {0, 0, 2}, {0, 0, -2}};
+		assertArrayEquals(new char[]{1, 0, 2}, sort(sorter(2, positions), direction(0, 0)));
+	}
+
+	private char[] sort(AlphaFaceSorter sorter, int[] direction)
+	{
+		return sort(sorter, direction, 123);
+	}
+
+	private char[] sort(AlphaFaceSorter sorter, int[] direction, int start)
+	{
+		IntBuffer output = IntBuffer.allocate(sorter.faceCount() * 3);
+		sorter.writeIndices(direction[0], direction[1], direction[2], direction[3], head, tail, next, output, start);
+		assertEquals(sorter.faceCount() * 3, output.position());
+		char[] faces = new char[sorter.faceCount()];
+		for (int i = 0; i < faces.length; ++i)
+		{
+			int first = output.get(i * 3);
+			assertEquals(first + 1, output.get(i * 3 + 1));
+			assertEquals(first + 2, output.get(i * 3 + 2));
+			assertEquals(0, (first - start) % 3);
+			faces[i] = (char) ((first - start) / 3);
+		}
+		return faces;
+	}
+
+	private static AlphaFaceSorter sorter(int radius, int[][] positions)
+	{
+		int[] packed = new int[positions.length];
+		for (int i = 0; i < positions.length; ++i)
+		{
+			int[] p = positions[i];
+			packed[i] = ((p[0] & 2047) << 21) | ((p[1] & 1023) << 11) | (p[2] & 2047);
+		}
+		return new AlphaFaceSorter(radius, packed);
+	}
+
+	private static int[] direction(int yaw, int pitch)
+	{
+		double unit = 3.834951969714103E-4D;
+		return new int[]{
+			(int) (65536.0 * Math.sin(yaw * unit)), (int) (65536.0 * Math.cos(yaw * unit)),
+			(int) (65536.0 * Math.sin(pitch * unit)), (int) (65536.0 * Math.cos(pitch * unit))
+		};
+	}
+
+	private static char[] expected(int[][] positions, int[] direction)
+	{
+		int[] depth = new int[positions.length];
+		Integer[] faces = new Integer[positions.length];
+		for (int i = 0; i < positions.length; ++i)
+		{
+			int[] p = positions[i];
+			int t = (p[2] * direction[1] - p[0] * direction[0]) >> 16;
+			depth[i] = (p[1] * direction[2] + t * direction[3]) >> 16;
+			faces[i] = i;
+		}
+		// Object sorting is stable, preserving the original face order on ties.
+		Arrays.sort(faces, (a, b) -> Integer.compare(depth[b], depth[a]));
+		char[] result = new char[faces.length];
+		for (int i = 0; i < faces.length; ++i)
+		{
+			result[i] = (char) (int) faces[i];
+		}
+		return result;
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/gpu/ZoneTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/gpu/ZoneTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.gpu;
+
+import net.runelite.api.Scene;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ZoneTest
+{
+	@Test
+	public void sharesStaticFaceOrderWithNeighboringZoneAndReleasesTemporaryCopy()
+	{
+		Zone source = new Zone();
+		Zone destination = new Zone();
+		Zone[][] zones = {{source}, {destination}};
+		Zone.AlphaModel model = new Zone.AlphaModel();
+		model.faceSorter = new AlphaFaceSorter(2, new int[]{0});
+		model.lx = model.lz = 0;
+		model.ux = 15;
+		model.uz = 7;
+		source.alphaModels.add(model);
+
+		// A non-toplevel scene has no extended-scene coordinate offset.
+		Scene scene = mock(Scene.class);
+		when(scene.getWorldViewId()).thenReturn(1);
+		source.multizoneLocs(scene, 0, 0, 1536, 512, zones);
+
+		assertEquals(1, destination.alphaModels.size());
+		Zone.AlphaModel copy = destination.alphaModels.get(0);
+		try
+		{
+			assertSame(model.faceSorter, copy.faceSorter);
+			assertFalse(copy.isTemp());
+			assertEquals(Zone.AlphaModel.TEMP, copy.flags);
+			assertEquals(Zone.AlphaModel.SKIP, model.flags);
+
+			destination.removeTemp();
+			source.removeTemp();
+
+			assertTrue(destination.alphaModels.isEmpty());
+			assertNull(copy.faceSorter);
+			assertTrue(copy.isTemp());
+			assertEquals(0, model.flags);
+			assertEquals(1, source.alphaModels.size());
+		}
+		finally
+		{
+			Zone.modelCache.remove(copy);
+		}
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/grounditems/GroundItemMenuEntriesTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/grounditems/GroundItemMenuEntriesTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.grounditems;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
+import net.runelite.client.menus.TestMenuEntry;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import org.junit.Test;
+
+public class GroundItemMenuEntriesTest
+{
+	@Test
+	public void testKeepsLastDuplicateAndMenuOrder()
+	{
+		MenuEntry first = entry(MenuAction.GROUND_ITEM_THIRD_OPTION, 1);
+		MenuEntry walk = entry(MenuAction.WALK, 0);
+		MenuEntry last = entry(MenuAction.GROUND_ITEM_THIRD_OPTION, 1);
+		MenuEntry examine = entry(MenuAction.EXAMINE_ITEM_GROUND, 1);
+		MenuEntry[] collapsed = GroundItemsPlugin.collapseEntries(new MenuEntry[]{first, walk, last, examine});
+		assertArrayEquals(new MenuEntry[]{walk, last, examine}, collapsed);
+		assertSame(last, collapsed[1]);
+		assertEquals("Item 1 x 2", last.getTarget());
+		assertEquals("Item 1", first.getTarget());
+	}
+
+	@Test
+	public void testOnlyCollapsesGroundActions()
+	{
+		for (MenuAction action : new MenuAction[]{MenuAction.GROUND_ITEM_FIRST_OPTION,
+			MenuAction.GROUND_ITEM_SECOND_OPTION, MenuAction.GROUND_ITEM_THIRD_OPTION,
+			MenuAction.GROUND_ITEM_FOURTH_OPTION, MenuAction.GROUND_ITEM_FIFTH_OPTION,
+			MenuAction.EXAMINE_ITEM_GROUND})
+		{
+			MenuEntry last = entry(action, 1);
+			MenuEntry[] collapsed = GroundItemsPlugin.collapseEntries(new MenuEntry[]{entry(action, 1), last});
+			assertEquals(1, collapsed.length);
+			assertSame(last, collapsed[0]);
+			assertEquals("Item 1 x 2", last.getTarget());
+		}
+
+		MenuEntry[] entries = {entry(MenuAction.WALK, 1), entry(MenuAction.WALK, 1),
+			entry(MenuAction.WIDGET_TARGET_ON_GROUND_ITEM, 1), entry(MenuAction.WIDGET_TARGET_ON_GROUND_ITEM, 1)};
+		assertArrayEquals(entries, GroundItemsPlugin.collapseEntries(entries));
+	}
+
+	@Test
+	public void testDistinctActionMetadataIsPreserved()
+	{
+		MenuEntry[] entries = {
+			entry(MenuAction.GROUND_ITEM_THIRD_OPTION, 1),
+			entry(MenuAction.GROUND_ITEM_THIRD_OPTION, 2),
+			entry(MenuAction.GROUND_ITEM_THIRD_OPTION, 1).setParam0(2),
+			entry(MenuAction.GROUND_ITEM_THIRD_OPTION, 1).setParam1(2),
+			entry(MenuAction.GROUND_ITEM_THIRD_OPTION, 1).setItemId(2),
+			entry(MenuAction.GROUND_ITEM_THIRD_OPTION, 1).setWorldViewId(2),
+			entry(MenuAction.GROUND_ITEM_THIRD_OPTION, 1).setForceLeftClick(true),
+			entry(MenuAction.GROUND_ITEM_THIRD_OPTION, 1).setDeprioritized(true),
+			entry(MenuAction.GROUND_ITEM_THIRD_OPTION, 1).setOption("Different"),
+			entry(MenuAction.GROUND_ITEM_THIRD_OPTION, 1).setTarget("Different")
+		};
+		assertArrayEquals(entries, GroundItemsPlugin.collapseEntries(entries));
+	}
+
+	@Test
+	public void testHashCollisionsStillCheckEquality()
+	{
+		MenuEntry[] entries = new MenuEntry[35];
+		for (int i = 0; i < entries.length; i++)
+		{
+			entries[i] = new TestMenuEntry()
+			{
+				@Override
+				public int hashCode()
+				{
+					return 1;
+				}
+			}.setType(MenuAction.GROUND_ITEM_THIRD_OPTION).setIdentifier(i % 34)
+				.setOption("Take").setTarget("Item");
+		}
+		MenuEntry[] collapsed = GroundItemsPlugin.collapseEntries(entries);
+		assertArrayEquals(Arrays.copyOfRange(entries, 1, entries.length), collapsed);
+		assertEquals("Item x 2", entries[34].getTarget());
+	}
+
+	@Test
+	public void testMatchesOriginalCollapse()
+	{
+		MenuAction[] actions = {MenuAction.WALK, MenuAction.RUNELITE, MenuAction.GROUND_ITEM_THIRD_OPTION,
+			MenuAction.EXAMINE_ITEM_GROUND, MenuAction.WIDGET_TARGET_ON_GROUND_ITEM};
+		Random random = new Random(0xC011A95E);
+		for (int iteration = 0; iteration < 100; iteration++)
+		{
+			int size = random.nextInt(501);
+			MenuEntry[] original = new MenuEntry[size];
+			MenuEntry[] optimized = new MenuEntry[size];
+			for (int i = 0; i < size; i++)
+			{
+				MenuAction action = actions[random.nextInt(actions.length)];
+				int id = random.nextInt(20);
+				int x = random.nextInt(3);
+				int worldView = random.nextInt(2);
+				original[i] = entry(action, id).setParam0(x).setWorldViewId(worldView);
+				optimized[i] = entry(action, id).setParam0(x).setWorldViewId(worldView);
+			}
+			assertArrayEquals(originalCollapse(original), GroundItemsPlugin.collapseEntries(optimized));
+		}
+		assertEquals(0, GroundItemsPlugin.collapseEntries(new MenuEntry[0]).length);
+	}
+
+	private static MenuEntry entry(MenuAction action, int id)
+	{
+		return new TestMenuEntry().setOption("Option").setTarget("Item " + id)
+			.setIdentifier(id).setType(action).setParam0(1).setParam1(1);
+	}
+
+	private static MenuEntry[] originalCollapse(MenuEntry[] menuEntries)
+	{
+		List<MenuEntryWithCount> entries = new ArrayList<>();
+		outer:
+		for (int i = menuEntries.length - 1; i >= 0; i--)
+		{
+			MenuEntry candidate = menuEntries[i];
+			MenuAction action = candidate.getType();
+			if (action == MenuAction.GROUND_ITEM_FIRST_OPTION || action == MenuAction.GROUND_ITEM_SECOND_OPTION
+				|| action == MenuAction.GROUND_ITEM_THIRD_OPTION || action == MenuAction.GROUND_ITEM_FOURTH_OPTION
+				|| action == MenuAction.GROUND_ITEM_FIFTH_OPTION || action == MenuAction.EXAMINE_ITEM_GROUND)
+			{
+				for (MenuEntryWithCount retained : entries)
+				{
+					if (retained.getEntry().equals(candidate))
+					{
+						retained.increment();
+						continue outer;
+					}
+				}
+			}
+			entries.add(new MenuEntryWithCount(candidate));
+		}
+		Collections.reverse(entries);
+		return entries.stream().map(e ->
+		{
+			MenuEntry entry = e.getEntry();
+			if (e.getCount() > 1)
+			{
+				entry.setTarget(entry.getTarget() + " x " + e.getCount());
+			}
+			return entry;
+		}).toArray(MenuEntry[]::new);
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/grounditems/ItemListTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/grounditems/ItemListTest.java
@@ -24,9 +24,12 @@
  */
 package net.runelite.client.plugins.grounditems;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 import joptsimple.internal.Strings;
+import net.runelite.client.util.WildcardMatcher;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import org.junit.Test;
@@ -71,5 +74,78 @@ public class ItemListTest
 		ItemList loader = new ItemList(List.of(name + "* < 100"));
 		assertNotEquals(ItemList.NONE, loader.matches(item(name, 50)));
 		assertEquals(ItemList.NONE, loader.matches(item(name, 150)));
+	}
+
+	@Test
+	public void testExactPrecedenceAndDuplicateThresholds()
+	{
+		ItemList loader = new ItemList(Arrays.asList("*", "Coins < 10", "COINS > 100"));
+		assertEquals(ItemList.EXACT, loader.matches(item("coins", 9)));
+		assertEquals(ItemList.WILDCARD, loader.matches(item("coins", 10)));
+		assertEquals(ItemList.WILDCARD, loader.matches(item("coins", 100)));
+		assertEquals(ItemList.EXACT, loader.matches(item("coins", 101)));
+	}
+
+	@Test
+	public void testUnicodeCaseFolding()
+	{
+		ItemList exact = new ItemList(Arrays.asList("I", "\u03a3", "\ud801\udc00"));
+		assertEquals(ItemList.EXACT, exact.matches(item("\u0131", 1)));
+		assertEquals(ItemList.EXACT, exact.matches(item("\u0130", 1)));
+		assertEquals(ItemList.EXACT, exact.matches(item("\u03c2", 1)));
+		assertEquals("\ud801\udc00".equalsIgnoreCase("\ud801\udc28") ? ItemList.EXACT : ItemList.NONE,
+			exact.matches(item("\ud801\udc28", 1)));
+
+		// Wildcards retain the regex matcher's ASCII-only case folding.
+		assertEquals(ItemList.NONE, new ItemList(List.of("I*")).matches(item("\u0131", 1)));
+	}
+
+	@Test
+	public void testMatchesOriginalSearch()
+	{
+		List<String> names = Arrays.asList("Coins", "COINS", "Abyssal whip", "Rune (platebody)",
+			"a.b", "\\E", "I", "\u0131", "line\nbreak", "\ud83d\udc02");
+		List<String> entries = Arrays.asList("Coins < 10", "coins > 50", "*whip", "Rune (*) > 4",
+			"a.*", "\\E*", "I < 2", "I* > 3", "line*break", "\ud83d\udc02*", "", null);
+		Random random = new Random(0xCA5E);
+		for (int iteration = 0; iteration < 100; iteration++)
+		{
+			List<String> selected = new ArrayList<>();
+			for (int i = 0; i < 30; i++)
+			{
+				selected.add(entries.get(random.nextInt(entries.size())));
+			}
+			ItemList loader = new ItemList(selected);
+			for (String name : names)
+			{
+				for (int quantity : new int[]{0, 1, 2, 4, 5, 9, 10, 50, 51})
+				{
+					GroundItem item = item(name, quantity);
+					assertEquals(originalMatches(selected, item), loader.matches(item));
+				}
+			}
+		}
+	}
+
+	private static int originalMatches(List<String> entries, GroundItem item)
+	{
+		int result = ItemList.NONE;
+		for (String entry : entries)
+		{
+			ItemThreshold threshold = ItemThreshold.fromName(entry);
+			if (threshold == null || !threshold.quantityHolds(item.getQuantity()))
+			{
+				continue;
+			}
+			if (!threshold.isWildcard() && threshold.getName().equalsIgnoreCase(item.getName()))
+			{
+				return ItemList.EXACT;
+			}
+			if (threshold.isWildcard() && WildcardMatcher.matches(threshold.getName(), item.getName()))
+			{
+				result = ItemList.WILDCARD;
+			}
+		}
+		return result;
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/util/TextTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/TextTest.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.client.util;
 
+import java.util.Random;
+import java.util.regex.Pattern;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
@@ -41,6 +43,36 @@ public class TextTest
 		assertEquals("a < b", Text.removeTags("a < b"));
 		assertEquals("a  b", Text.removeTags("a <lt> b"));
 		assertEquals("Remove no tags", Text.removeTags("Remove no tags"));
+	}
+
+	@Test
+	public void removeTagsMalformedInput()
+	{
+		assertEquals("", Text.removeTags(""));
+		assertEquals("ab", Text.removeTags("a<>b"));
+		assertEquals("a>b", Text.removeTags("a<<nested>><tag>b"));
+		assertEquals("a>b<unfinished", Text.removeTags("a><tag>b<unfinished"));
+		assertEquals("ab", Text.removeTags("a<line\nbreak>b"));
+		assertEquals("<".repeat(4096), Text.removeTags("<".repeat(4096)));
+	}
+
+	@Test
+	public void removeTagsMatchesRegex()
+	{
+		Pattern reference = Pattern.compile("<([^>]*)>");
+		Random random = new Random(0x7A65);
+		String alphabet = "ab<>\n\r\u0085\u2028\u2029\uD83D\uDE00";
+		for (int sample = 0; sample < 10_000; sample++)
+		{
+			StringBuilder input = new StringBuilder();
+			int length = random.nextInt(100);
+			for (int i = 0; i < length; i++)
+			{
+				input.append(alphabet.charAt(random.nextInt(alphabet.length())));
+			}
+			String text = input.toString();
+			assertEquals(reference.matcher(text).replaceAll(""), Text.removeTags(text));
+		}
 	}
 
 	@Test

--- a/runelite-client/src/test/java/net/runelite/client/util/WildcardMatcherTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/WildcardMatcherTest.java
@@ -41,4 +41,22 @@ public class WildcardMatcherTest
 		assertTrue(matches("Abyssal whip", "Abyssal whip"));
 		assertTrue(matches("string $ with special character", "string $ with special character"));
 	}
+
+	@Test
+	public void testCompiledPatterns()
+	{
+		var rune = WildcardMatcher.compile("**rune***");
+		assertTrue(rune.matcher("Rune pouch").matches());
+		assertTrue(rune.matcher("Nature rune").matches());
+		assertFalse(rune.matcher("Abyssal whip").matches());
+		assertTrue(WildcardMatcher.compile("").matcher("").matches());
+		assertTrue(WildcardMatcher.compile("*").matcher("").matches());
+		assertTrue(WildcardMatcher.compile("Rune (*)").matcher("Rune (platebody)").matches());
+		assertTrue(WildcardMatcher.compile("a.b*").matcher("a.b literal").matches());
+		assertFalse(WildcardMatcher.compile("a.b*").matcher("axb literal").matches());
+		assertFalse(WildcardMatcher.compile("I*").matcher("\u0131").matches());
+		assertFalse(WildcardMatcher.compile("line*break").matcher("line\nbreak").matches());
+		assertTrue(WildcardMatcher.compile("line\nbreak").matcher("line\nbreak").matches());
+		assertTrue(WildcardMatcher.compile("\\E*").matcher("\\E literal").matches());
+	}
 }


### PR DESCRIPTION
This PR contains eight performance optimizations that reduce repeated searches, regex compilation, sorting, and buffer copying. The changes include regression tests; benchmark scripts, results files, and additional documentation are excluded from the PR.

Measurements were collected using synthetic workloads on OpenJDK 17.0.20 in a shared Linux development container. The timings below refer to individual operations or the specified batches, not overall game FPS.

* **Archive-name lookup:** Replace repeated linear scans with a lazily built index, invalidated when archives are added, removed, or renamed. A batch of 50,574 warm lookups across 20,000 archives improved from **1,972.584 ms to 1.363 ms**, approximately **1,447× faster**. Initial index construction is excluded.

* **Archive serialization:** Allocate output to its known size and eliminate per-file chunk-size arrays during decoding. Saving one 1 MiB file improved from **0.930 ms to 0.339 ms**, approximately **2.74× faster**. Allocations fell from approximately **3.15 MB to 1.05 MB**.

* **Polygon construction:** Grow vertex buffers geometrically and reuse available append capacity, preserving self-append and shared-array behavior. Building a 1,024-vertex polygon through repeated small appends improved from **0.335449 ms to 0.017373 ms**, approximately **19.31× faster**.

* **Rectangle unions:** Index predecessor searches once the sweep exceeds 256 segment nodes, retaining linear lookup for small inputs. A union of 4,096 overlapping rectangles improved from **7.504552 ms to 4.634888 ms**, approximately **1.62× faster**. Degenerate-rectangle behavior is preserved.

* **Ground-item matching:** Index exact names and precompile wildcard rules while preserving case handling, quantity thresholds, and exact-match precedence. Matching against 256 exact-name rules improved from **0.002470 ms to 0.000127 ms**, approximately **19.50× faster**. Matching against 64 wildcard rules improved from **0.096369 ms to 0.003747 ms**, approximately **25.72× faster**. Configuration-time construction is excluded.

* **Ground-item menus:** Use hash-based duplicate detection for menus larger than 32 entries, preserving menu order and the last duplicate. Collapsing 500 entries with 100 distinct entries improved from **0.174994 ms to 0.046464 ms**, approximately **3.77× faster**.

* **GPU alpha sorting:** Cache static translucent face order when camera direction repeats, share the cache across neighboring-zone proxies, and invalidate it when direction changes. For 4,096 translucent faces with a warm stationary-camera cache, CPU sorting and index emission improved from **0.060840 ms to 0.016795 ms**, approximately **3.62× faster**.

* **Text tag removal:** Replace regex-based removal with a linear scan while preserving existing tag and malformed-input behavior. Formatted-text processing improved from approximately **0.000513 ms to 0.000095 ms**, approximately **5.42× faster**, with fewer allocations.

Validation completed successfully: **748 tests reported, 721 passed, 27 skipped, and zero failures or errors**. A final targeted rerun passed all 21 tests. Client PMD reported zero violations, and repository Checkstyle passed all 21 changed production/test Java files. Mockito required the existing ByteBuddy agent at JVM startup through a temporary init script in this environment; normal build configuration was unchanged.

The optimizations have workload and memory tradeoffs. Large indexes and menu maps allocate additional memory. The GPU cache retains two bytes per cached face plus per-model overhead, and warmed measurements exclude cache population. Moving-camera GPU results were mixed, with dense workloads near parity. One small rectangle-union workload measured 7% slower.