### PR TITLE
Item stats: show poison status on remedy tooltips

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
@@ -404,6 +404,7 @@ public class ItemStatChanges
 		add(combo(food(15), heal(PRAYER, perc(.25, 0)), staminaPot), ItemID.DT2_SCAR_MAZE_STAMINA);
 		add(new DwarvenRockCake(), ItemID.HUNDRED_DWARF_COOL_ROCKCAKE);
 		add(new LocatorOrb(), ItemID.DS2_ORB);
+		add(heal(HITPOINTS, -4), ItemID.ARAXYTE_VENOM_SACK);
 
 		// Gauntlet
 		add(combo(heal(PRAYER, perc(.25, 7)), heal(RUN_ENERGY, 40)), ItemID.GAUNTLET_POTION_1, ItemID.GAUNTLET_POTION_2, ItemID.GAUNTLET_POTION_3, ItemID.GAUNTLET_POTION_4);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -30,6 +30,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.time.Duration;
+import java.time.Instant;
 import net.runelite.api.Client;
 import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.Item;
@@ -74,6 +75,9 @@ public class ItemStatOverlay extends Overlay
 
 	@Inject
 	private ItemStatConfig config;
+
+	@Inject
+	private PoisonStatus poisonStatus;
 
 	@Override
 	public Dimension render(Graphics2D graphics)
@@ -178,6 +182,15 @@ public class ItemStatOverlay extends Overlay
 							sb.append('~');
 							sb.append(DurationFormatUtils.formatDuration(highestDuration.toMillis(), "m:ss"));
 						}
+					}
+				}
+
+				if (p.isPoisonRemedy())
+				{
+					final String venomTooltip = poisonStatus.createTooltip(Instant.now());
+					if (venomTooltip != null)
+					{
+						sb.append("</br>").append(venomTooltip);
 					}
 				}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
@@ -31,6 +31,7 @@ import com.google.inject.Binder;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import java.awt.FontMetrics;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -95,6 +96,9 @@ public class ItemStatPlugin extends Plugin
 	@Inject
 	private ClientThread clientThread;
 
+	@Inject
+	private PoisonStatus poisonStatus;
+
 	private Widget itemInformationTitle;
 
 	@Provides
@@ -119,6 +123,7 @@ public class ItemStatPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		overlayManager.remove(overlay);
+		poisonStatus.clear();
 		clientThread.invokeLater(this::resetGEInventory);
 	}
 
@@ -148,6 +153,10 @@ public class ItemStatPlugin extends Plugin
 		if (event.getVarpId() == VarPlayerID.TRADINGPOST_SEARCH && config.geStats())
 		{
 			resetGEInventory();
+		}
+		else if (event.getVarpId() == VarPlayerID.POISON)
+		{
+			poisonStatus.update(event.getValue(), Instant.now());
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/PoisonStatus.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/PoisonStatus.java
@@ -1,0 +1,65 @@
+package net.runelite.client.plugins.itemstats;
+
+import com.google.inject.Singleton;
+import java.awt.Color;
+import java.text.MessageFormat;
+import java.time.Duration;
+import java.time.Instant;
+import net.runelite.client.util.ColorUtil;
+
+@Singleton
+class PoisonStatus
+{
+	private static final int POISON_TICK_MILLIS = 18200;
+	private static final int VENOM_THRESHOLD = 1000000;
+	private static final int VENOM_MAXIMUM_DAMAGE = 20;
+
+	private int nextDamage;
+	private boolean envenomed;
+	private Instant nextTick;
+
+	void update(int poisonValue, Instant now)
+	{
+		if (poisonValue > 0)
+		{
+			nextDamage = nextDamage(poisonValue);
+			envenomed = poisonValue >= VENOM_THRESHOLD;
+			nextTick = now.plusMillis(POISON_TICK_MILLIS);
+		}
+		else
+		{
+			clear();
+		}
+	}
+
+	void clear()
+	{
+		nextDamage = 0;
+		envenomed = false;
+		nextTick = null;
+	}
+
+	static int nextDamage(int poisonValue)
+	{
+		if (poisonValue >= VENOM_THRESHOLD)
+		{
+			final int damage = (poisonValue - VENOM_THRESHOLD + 3) * 2;
+			return Math.min(damage, VENOM_MAXIMUM_DAMAGE);
+		}
+
+		return (int) Math.ceil(poisonValue / 5.0f);
+	}
+
+	String createTooltip(Instant now)
+	{
+		if (nextTick == null)
+		{
+			return null;
+		}
+
+		final long seconds = Math.max(0, Duration.between(now, nextTick).toMillis() / 1000L);
+		return MessageFormat.format("Next {0} damage: {1}</br>Time until damage: {2}:{3,number,00}",
+			envenomed ? "venom" : "poison", ColorUtil.wrapWithColorTag(String.valueOf(nextDamage), Color.RED),
+			seconds / 60, seconds % 60);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/potions/PotionDuration.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/potions/PotionDuration.java
@@ -33,49 +33,72 @@ import net.runelite.api.gameval.ItemID;
 
 public enum PotionDuration
 {
-	ANTIPOISON(Duration.ofSeconds(90), ItemID._4DOSEANTIPOISON, ItemID._3DOSEANTIPOISON, ItemID._2DOSEANTIPOISON, ItemID._1DOSEANTIPOISON),
-	SUPERANTIPOISON(Duration.ofMinutes(6), ItemID._4DOSE2ANTIPOISON, ItemID._3DOSE2ANTIPOISON, ItemID._2DOSE2ANTIPOISON, ItemID._1DOSE2ANTIPOISON),
-	ANTIDOTE_P(Duration.ofMinutes(9), ItemID.ANTIDOTE_4, ItemID.ANTIDOTE_3, ItemID.ANTIDOTE_2, ItemID.ANTIDOTE_1),
-	ANTIDOTE_PP(Duration.ofMinutes(12), ItemID.ANTIDOTE__4, ItemID.ANTIDOTE__3, ItemID.ANTIDOTE__2, ItemID.ANTIDOTE__1),
-	ANTIVENOM(new PotionDurationRange[]{
+	ANTIPOISON(Duration.ofSeconds(90), true, ItemID._4DOSEANTIPOISON, ItemID._3DOSEANTIPOISON, ItemID._2DOSEANTIPOISON, ItemID._1DOSEANTIPOISON),
+	SUPERANTIPOISON(Duration.ofMinutes(6), true, ItemID._4DOSE2ANTIPOISON, ItemID._3DOSE2ANTIPOISON, ItemID._2DOSE2ANTIPOISON, ItemID._1DOSE2ANTIPOISON),
+	SANFEW_SERUM(Duration.ofMinutes(6), true, ItemID.SANFEW_SALVE_4_DOSE, ItemID.SANFEW_SALVE_3_DOSE, ItemID.SANFEW_SALVE_2_DOSE, ItemID.SANFEW_SALVE_1_DOSE,
+		ItemID.BR_SANFEW_SALVE_4_DOSE, ItemID.BR_SANFEW_SALVE_3_DOSE, ItemID.BR_SANFEW_SALVE_2_DOSE, ItemID.BR_SANFEW_SALVE_1_DOSE),
+	ANTIDOTE_P(Duration.ofMinutes(9), true, ItemID.ANTIDOTE_4, ItemID.ANTIDOTE_3, ItemID.ANTIDOTE_2, ItemID.ANTIDOTE_1),
+	ANTIDOTE_PP(new PotionDurationRange[]{
 		new PotionDurationRange("Anti-venom", Duration.ofSeconds(18), Duration.ofSeconds(36)),
-		new PotionDurationRange("Anti-poison", Duration.ofMinutes(12))},
+		new PotionDurationRange("Anti-poison", Duration.ofMinutes(12))}, true,
+		ItemID.ANTIDOTE__4, ItemID.ANTIDOTE__3, ItemID.ANTIDOTE__2, ItemID.ANTIDOTE__1),
+	ANTIVENOM(new PotionDurationRange[]{
+		new PotionDurationRange("Anti-venom", Duration.ofSeconds(36), Duration.ofSeconds(54)),
+		new PotionDurationRange("Anti-poison", Duration.ofMinutes(12))}, true,
 		ItemID.ANTIVENOM4, ItemID.ANTIVENOM3, ItemID.ANTIVENOM2, ItemID.ANTIVENOM1),
+	ARAXYTE_VENOM_SAC(new PotionDurationRange[]{
+		new PotionDurationRange("Anti-venom", Duration.ZERO, Duration.ofSeconds(18)),
+		new PotionDurationRange("Anti-poison", Duration.ofSeconds(702))}, true,
+		ItemID.ARAXYTE_VENOM_SACK),
 	ANTIVENOM_P(new PotionDurationRange[]{
-		new PotionDurationRange("Anti-venom", Duration.ofMinutes(3)),
-		new PotionDurationRange("Anti-poison", Duration.ofMinutes(15))},
+		new PotionDurationRange("Anti-venom", Duration.ofSeconds(216)),
+		new PotionDurationRange("Anti-poison", Duration.ofMinutes(15))}, true,
 		ItemID.ANTIVENOM_4, ItemID.ANTIVENOM_3, ItemID.ANTIVENOM_2, ItemID.ANTIVENOM_1),
 	EXTENDED_ANTIVENOM_P(new PotionDurationRange[]{
-		new PotionDurationRange("Anti-venom", Duration.ofMinutes(6)),
-		new PotionDurationRange("Anti-poison", Duration.ofMinutes(17))},
+		new PotionDurationRange("Anti-venom", Duration.ofSeconds(378)),
+		new PotionDurationRange("Anti-poison", Duration.ofSeconds(1062))}, true,
 		ItemID.EXTENDED_ANTIVENOM_4, ItemID.EXTENDED_ANTIVENOM_3, ItemID.EXTENDED_ANTIVENOM_2, ItemID.EXTENDED_ANTIVENOM_1),
 	ANTIFIRE(Duration.ofMinutes(6), ItemID._4DOSE1ANTIDRAGON, ItemID._3DOSE1ANTIDRAGON, ItemID._2DOSE1ANTIDRAGON, ItemID._1DOSE1ANTIDRAGON),
 	EXTENDED_ANTIFIRE(Duration.ofMinutes(12), ItemID._4DOSE2ANTIDRAGON, ItemID._3DOSE2ANTIDRAGON, ItemID._2DOSE2ANTIDRAGON, ItemID._1DOSE2ANTIDRAGON),
 	SUPER_ANTIFIRE(Duration.ofMinutes(3), ItemID._4DOSE3ANTIDRAGON, ItemID._3DOSE3ANTIDRAGON, ItemID._2DOSE3ANTIDRAGON, ItemID._1DOSE3ANTIDRAGON),
 	EXTENDED_SUPER_ANTIFIRE(Duration.ofMinutes(6), ItemID._4DOSE4ANTIDRAGON, ItemID._3DOSE4ANTIDRAGON, ItemID._2DOSE4ANTIDRAGON, ItemID._1DOSE4ANTIDRAGON),
-	ANTIPOISON_MIX(Duration.ofSeconds(90), ItemID.BRUTAL_1DOSEANTIPOISON, ItemID.BRUTAL_2DOSEANTIPOISON),
-	ANTIPOISON_SUPERMIX(Duration.ofMinutes(6), ItemID.BRUTAL_1DOSE2ANTIPOISON, ItemID.BRUTAL_2DOSE2ANTIPOISON),
-	ANTIDOTE_PLUS_MIX(Duration.ofMinutes(9), ItemID.BRUTAL_ANTIDOTE_1, ItemID.BRUTAL_ANTIDOTE_2),
+	ANTIPOISON_MIX(Duration.ofSeconds(90), true, ItemID.BRUTAL_1DOSEANTIPOISON, ItemID.BRUTAL_2DOSEANTIPOISON),
+	ANTIPOISON_SUPERMIX(Duration.ofMinutes(6), true, ItemID.BRUTAL_1DOSE2ANTIPOISON, ItemID.BRUTAL_2DOSE2ANTIPOISON),
+	ANTIDOTE_PLUS_MIX(Duration.ofMinutes(9), true, ItemID.BRUTAL_ANTIDOTE_1, ItemID.BRUTAL_ANTIDOTE_2),
 	EXTENDED_ANTIFIRE_MIX(Duration.ofMinutes(12), ItemID.BRUTAL_1DOSE2ANTIDRAGON, ItemID.BRUTAL_2DOSE2ANTIDRAGON),
 	SUPER_ANTIFIRE_MIX(Duration.ofMinutes(3), ItemID.BRUTAL_1DOSE3ANTIDRAGON, ItemID.BRUTAL_2DOSE3ANTIDRAGON),
 	EXTENDED_SUPER_ANTIFIRE_MIX(Duration.ofMinutes(6), ItemID.BRUTAL_1DOSE4ANTIDRAGON, ItemID.BRUTAL_2DOSE4ANTIDRAGON);
 
 	@Getter
 	private final PotionDurationRange[] durationRanges;
+	@Getter
+	private final boolean poisonRemedy;
 	private final int[] itemIds;
 
 	PotionDuration(Duration duration, int... itemIds)
+	{
+		this(duration, false, itemIds);
+	}
+
+	PotionDuration(Duration duration, boolean poisonRemedy, int... itemIds)
 	{
 		PotionDurationRange[] ranges = new PotionDurationRange[1];
 		// Only need the duration, not the potion name or a range
 		ranges[0] = new PotionDurationRange("", duration);
 		this.durationRanges = ranges;
+		this.poisonRemedy = poisonRemedy;
 		this.itemIds = itemIds;
 	}
 
 	PotionDuration(PotionDurationRange[] durationRanges, int... itemIds)
 	{
+		this(durationRanges, false, itemIds);
+	}
+
+	PotionDuration(PotionDurationRange[] durationRanges, boolean poisonRemedy, int... itemIds)
+	{
 		this.durationRanges = durationRanges;
+		this.poisonRemedy = poisonRemedy;
 		this.itemIds = itemIds;
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatEffectTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatEffectTest.java
@@ -283,6 +283,16 @@ public class ItemStatEffectTest
 	}
 
 	@Test
+	public void testAraxyteVenomSac()
+	{
+		final Effect araxyteVenomSac = itemStats.get(ItemID.ARAXYTE_VENOM_SACK);
+
+		assertEquals(-4, hitpointsChange(99, araxyteVenomSac));
+		assertEquals(-4, hitpointsChange(4, araxyteVenomSac));
+		assertEquals(-3, hitpointsChange(3, araxyteVenomSac));
+	}
+
+	@Test
 	public void testAmbrosia()
 	{
 		final Effect ambrosia = new ItemStatChanges().get(ItemID.TOA_SUPPLY_PANICHEAL_2);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/PoisonStatusTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/PoisonStatusTest.java
@@ -1,0 +1,57 @@
+package net.runelite.client.plugins.itemstats;
+
+import java.time.Instant;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+
+public class PoisonStatusTest
+{
+	private final PoisonStatus poisonStatus = new PoisonStatus();
+
+	@Test
+	public void testVenomTooltip()
+	{
+		final Instant now = Instant.EPOCH;
+		poisonStatus.update(1000000, now);
+
+		assertEquals(
+			"Next venom damage: <col=ff0000>6</col></br>Time until damage: 0:18",
+			poisonStatus.createTooltip(now));
+		assertEquals(
+			"Next venom damage: <col=ff0000>6</col></br>Time until damage: 0:08",
+			poisonStatus.createTooltip(now.plusSeconds(10)));
+	}
+
+	@Test
+	public void testPoisonTooltip()
+	{
+		final Instant now = Instant.EPOCH;
+		poisonStatus.update(25, now);
+
+		assertEquals(
+			"Next poison damage: <col=ff0000>5</col></br>Time until damage: 0:18",
+			poisonStatus.createTooltip(now));
+	}
+
+	@Test
+	public void testNextDamage()
+	{
+		assertEquals(1, PoisonStatus.nextDamage(1));
+		assertEquals(1, PoisonStatus.nextDamage(5));
+		assertEquals(2, PoisonStatus.nextDamage(6));
+		assertEquals(6, PoisonStatus.nextDamage(1000000));
+		assertEquals(8, PoisonStatus.nextDamage(1000001));
+		assertEquals(20, PoisonStatus.nextDamage(1000007));
+		assertEquals(20, PoisonStatus.nextDamage(1000100));
+	}
+
+	@Test
+	public void testTooltipClearsWhenVenomIsCured()
+	{
+		poisonStatus.update(1000000, Instant.EPOCH);
+		poisonStatus.update(0, Instant.EPOCH);
+
+		assertNull(poisonStatus.createTooltip(Instant.EPOCH));
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/potions/PotionDurationTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/potions/PotionDurationTest.java
@@ -1,0 +1,70 @@
+package net.runelite.client.plugins.itemstats.potions;
+
+import java.time.Duration;
+import net.runelite.api.gameval.ItemID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class PotionDurationTest
+{
+	@Test
+	public void testAraxyteVenomSac()
+	{
+		final PotionDuration potionDuration = PotionDuration.get(ItemID.ARAXYTE_VENOM_SACK);
+		final PotionDuration.PotionDurationRange[] ranges = potionDuration.getDurationRanges();
+
+		assertEquals(2, ranges.length);
+		assertEquals("Anti-venom", ranges[0].getPotionName());
+		assertEquals(Duration.ZERO, ranges[0].getLowestDuration());
+		assertEquals(Duration.ofSeconds(18), ranges[0].getHighestDuration());
+		assertEquals("Anti-poison", ranges[1].getPotionName());
+		assertEquals(Duration.ofSeconds(702), ranges[1].getLowestDuration());
+		assertEquals(Duration.ofSeconds(702), ranges[1].getHighestDuration());
+	}
+
+	@Test
+	public void testVenomProtectionDurations()
+	{
+		assertRanges(PotionDuration.get(ItemID.ANTIDOTE__4),
+			Duration.ofSeconds(18), Duration.ofSeconds(36), Duration.ofMinutes(12));
+		assertRanges(PotionDuration.get(ItemID.ANTIVENOM4),
+			Duration.ofSeconds(36), Duration.ofSeconds(54), Duration.ofMinutes(12));
+		assertRanges(PotionDuration.get(ItemID.ANTIVENOM_4),
+			Duration.ofSeconds(216), Duration.ofSeconds(216), Duration.ofMinutes(15));
+		assertRanges(PotionDuration.get(ItemID.EXTENDED_ANTIVENOM_4),
+			Duration.ofSeconds(378), Duration.ofSeconds(378), Duration.ofSeconds(1062));
+	}
+
+	@Test
+	public void testPoisonRemedies()
+	{
+		assertTrue(PotionDuration.get(ItemID._4DOSEANTIPOISON).isPoisonRemedy());
+		assertTrue(PotionDuration.get(ItemID._4DOSE2ANTIPOISON).isPoisonRemedy());
+		assertTrue(PotionDuration.get(ItemID.SANFEW_SALVE_4_DOSE).isPoisonRemedy());
+		assertTrue(PotionDuration.get(ItemID.ANTIDOTE_4).isPoisonRemedy());
+		assertTrue(PotionDuration.get(ItemID.ANTIDOTE__4).isPoisonRemedy());
+		assertTrue(PotionDuration.get(ItemID.ARAXYTE_VENOM_SACK).isPoisonRemedy());
+		assertTrue(PotionDuration.get(ItemID.ANTIVENOM4).isPoisonRemedy());
+		assertTrue(PotionDuration.get(ItemID.ANTIVENOM_4).isPoisonRemedy());
+		assertTrue(PotionDuration.get(ItemID.EXTENDED_ANTIVENOM_4).isPoisonRemedy());
+		assertTrue(PotionDuration.get(ItemID.BRUTAL_1DOSEANTIPOISON).isPoisonRemedy());
+		assertTrue(PotionDuration.get(ItemID.BRUTAL_1DOSE2ANTIPOISON).isPoisonRemedy());
+		assertTrue(PotionDuration.get(ItemID.BRUTAL_ANTIDOTE_1).isPoisonRemedy());
+		assertFalse(PotionDuration.get(ItemID._4DOSE1ANTIDRAGON).isPoisonRemedy());
+	}
+
+	private static void assertRanges(PotionDuration potionDuration, Duration lowestVenom,
+		Duration highestVenom, Duration poison)
+	{
+		final PotionDuration.PotionDurationRange[] ranges = potionDuration.getDurationRanges();
+
+		assertEquals("Anti-venom", ranges[0].getPotionName());
+		assertEquals(lowestVenom, ranges[0].getLowestDuration());
+		assertEquals(highestVenom, ranges[0].getHighestDuration());
+		assertEquals("Anti-poison", ranges[1].getPotionName());
+		assertEquals(poison, ranges[1].getLowestDuration());
+		assertEquals(poison, ranges[1].getHighestDuration());
+	}
+}


### PR DESCRIPTION
Adds live poison and venom information to Item Stats tooltips for relevant remedies:

- Next poison or venom damage
- Time until the next damage
- Araxyte venom sac's potentially lethal Hitpoints cost

This applies to antipoisons, antidotes, Sanfew serum, barbarian mixes, anti-venoms, and Araxyte venom sacs.

Also corrects the displayed immunity durations for Antidote++, anti-venom, anti-venom+, and extended anti-venom+, and adds Sanfew serum's poison immunity duration.

Fixes #20501
Fixes #20333
Partially addresses #15910 — this adds Sanfew serum's poison immunity duration, but not its disease immunity or Relicym's balm information.

### Screenshots

<!-- Image 1: poison remedy tooltip -->
<img width="322" height="384" alt="Time until damage antidote" src="https://github.com/user-attachments/assets/54cdd7a4-1689-41be-90a2-81b89cb10555" />

<!-- Image 2: venom/Araxyte venom sac tooltip -->
<img width="326" height="354" alt="Time until damage venom sac" src="https://github.com/user-attachments/assets/cff78b62-3896-45cb-b787-5403022e7c0c" />


### Testing

```sh
./gradlew :client:test \
  --tests net.runelite.client.plugins.itemstats.PoisonStatusTest \
  --tests net.runelite.client.plugins.itemstats.ItemStatEffectTest \
  --tests net.runelite.client.plugins.itemstats.potions.PotionDurationTest

./gradlew :client:check
./gradlew :client:shadowJar
```
